### PR TITLE
docs: add y and m keybindings to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ uv run python -m gantry --debug
 | `c` | Context + namespace picker |
 | `/` | Search / filter |
 | `d` | Describe selected resource |
+| `y` | View YAML manifest |
+| `m` | Toggle YAML mode (full / spec-only) |
 | `l` | View pod logs |
 | `r` | Refresh |
 | `Enter` | Deploy Helm chart |


### PR DESCRIPTION
Document the YAML manifest viewer keybindings (`y` to view, `m` to toggle between full and spec-only mode) that are already implemented in screens.py but were missing from the README keybindings table.

Closes #5

Generated with [Claude Code](https://claude.ai/code)