### PR TITLE
fix: prevent DuplicateIds crash when pressing y twice

### DIFF
--- a/src/gantry/screens.py
+++ b/src/gantry/screens.py
@@ -11,6 +11,7 @@ from textual.binding import Binding
 from textual.message import Message
 from textual import work
 from textual.reactive import reactive
+from textual.css.query import NoMatches
 import json
 
 from gantry import k8s, state
@@ -724,11 +725,14 @@ class ClusterScreen(Screen):
         detail_panel = self.query_one("#detail-panel", VerticalScroll)
         detail_content = self.query_one("#detail-panel-content", Static)
 
-        # Remove existing TextArea if present
-        if self._yaml_text_area is not None:
-            if self._yaml_text_area.is_attached:
-                self._yaml_text_area.remove()
-            self._yaml_text_area = None
+        # Remove existing TextArea if present — query DOM directly so concurrent
+        # background workers don't race on the stale is_attached check.
+        try:
+            old_textarea = detail_panel.query_one("#yaml-content", TextArea)
+            old_textarea.remove()
+        except NoMatches:
+            pass
+        self._yaml_text_area = None
 
         # Hide the Static description widget
         detail_content.add_class("hidden")


### PR DESCRIPTION
Query the detail panel DOM directly for any existing #yaml-content widget and remove it before mounting a new one, instead of relying on the is_attached check which races with background YAML fetch workers.

Fixes #13

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YAML panel refresh reliability by enhancing error handling for concurrent updates, ensuring the refresh process completes safely even when the panel content is being modified simultaneously.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->