### PR TITLE
fix: reuse TextArea in _show_yaml_panel to prevent DuplicateIds crash

### DIFF
--- a/src/gantry/screens.py
+++ b/src/gantry/screens.py
@@ -725,28 +725,25 @@ class ClusterScreen(Screen):
         detail_panel = self.query_one("#detail-panel", VerticalScroll)
         detail_content = self.query_one("#detail-panel-content", Static)
 
-        # Remove existing TextArea if present — query DOM directly so concurrent
-        # background workers don't race on the stale is_attached check.
-        try:
-            old_textarea = detail_panel.query_one("#yaml-content", TextArea)
-            old_textarea.remove()
-        except NoMatches:
-            pass
-        self._yaml_text_area = None
+        # Reuse the existing TextArea if it is still in the DOM to avoid the
+        # async remove-then-mount race that causes DuplicateIds when `y` is
+        # pressed while the panel is already open.
+        if self._yaml_text_area is not None and self._yaml_text_area.is_attached:
+            self._yaml_text_area.load_text(yaml_content)
+            self._yaml_text_area.language = "yaml"
+        else:
+            text_area = TextArea(
+                yaml_content,
+                language="yaml",
+                theme="monokai",
+                read_only=True,
+                id="yaml-content",
+            )
+            detail_panel.mount(text_area)
+            self._yaml_text_area = text_area
 
         # Hide the Static description widget
         detail_content.add_class("hidden")
-
-        # Mount read-only TextArea with YAML syntax highlighting
-        text_area = TextArea(
-            yaml_content,
-            language="yaml",
-            theme="monokai",
-            read_only=True,
-            id="yaml-content",
-        )
-        detail_panel.mount(text_area)
-        self._yaml_text_area = text_area
 
         detail_panel.add_class("show")
         self.detail_panel_open = True

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -536,6 +536,27 @@ async def test_teardown_yaml_panel_removes_text_area():
 
 
 @pytest.mark.asyncio
+async def test_apply_yaml_result_twice_no_duplicate_ids():
+    """Calling _apply_yaml_result twice must not raise DuplicateIds."""
+    app = GantryApp()
+    async with app.run_test() as pilot:
+        screen = app.screen
+        assert isinstance(screen, ClusterScreen)
+
+        screen._apply_yaml_result(("apiVersion: v1\nkind: Pod\n", "apiVersion: v1\n"))
+        await pilot.pause()
+        assert screen.yaml_view_open is True
+
+        # Second call simulates pressing 'y' while the panel is already open
+        screen._apply_yaml_result(("apiVersion: v1\nkind: Service\n", "apiVersion: v1\n"))
+        await pilot.pause()
+
+        assert screen.yaml_view_open is True
+        text_areas = screen.query("#yaml-content")
+        assert len(text_areas) == 1, "Expected exactly one #yaml-content widget"
+
+
+@pytest.mark.asyncio
 async def test_yaml_panel_closed_when_describe_called():
     """yaml_view_open should be False after describe is invoked while YAML was open."""
     app = GantryApp()


### PR DESCRIPTION
Replaces the async remove-then-mount pattern in `_show_yaml_panel()` with a reuse-or-mount check to prevent the `DuplicateIds` crash when pressing `y` while the YAML panel is already open.

Also adds a regression test `test_apply_yaml_result_twice_no_duplicate_ids`.

Closes #15

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed YAML panel to prevent duplicate widgets when opened multiple times.
  * Improved YAML panel performance by reusing components instead of recreating them.

* **Tests**
  * Added test to ensure YAML panel remains stable when repeatedly activated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->