### PR TITLE
fix: change sidepanel to rightpanel ratio to 20:80

### DIFF
--- a/src/gantry/screens.py
+++ b/src/gantry/screens.py
@@ -218,7 +218,7 @@ class ClusterScreen(Screen):
     }
 
     #resource-type-sidebar {
-        width: 24;
+        width: 20%;
         height: 100%;
         border-right: solid $accent;
         background: $panel;


### PR DESCRIPTION
Changed #resource-type-sidebar width from fixed 24 characters to 20%, giving a responsive 20:80 split with the main content area.

Closes #25

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* Updated cluster screen sidebar width to use responsive percentage-based sizing for improved layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->