### PR TITLE
feat: add syntax highlighting for Helm templates and YAML

### DIFF
--- a/charts/agent/.helmignore
+++ b/charts/agent/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: agent
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/charts/agent/templates/NOTES.txt
+++ b/charts/agent/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "agent.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "agent.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "agent.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "agent.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "agent.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "agent.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "agent.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "agent.labels" -}}
+helm.sh/chart: {{ include "agent.chart" . }}
+{{ include "agent.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "agent.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "agent.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "agent.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "agent.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/agent/templates/deployment.yaml
+++ b/charts/agent/templates/deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "agent.fullname" . }}
+  labels:
+    {{- include "agent.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "agent.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "agent.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "agent.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/agent/templates/hpa.yaml
+++ b/charts/agent/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "agent.fullname" . }}
+  labels:
+    {{- include "agent.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "agent.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/agent/templates/hpa.yaml
+++ b/charts/agent/templates/hpa.yaml
@@ -12,6 +12,7 @@ spec:
     name: {{ include "agent.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  {{- if or .Values.autoscaling.targetCPUUtilizationPercentage .Values.autoscaling.targetMemoryUtilizationPercentage }}
   metrics:
     {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
@@ -29,4 +30,5 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/agent/templates/ingress.yaml
+++ b/charts/agent/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "agent.fullname" . }}
+  labels:
+    {{- include "agent.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ include "agent.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/agent/templates/ingress.yaml
+++ b/charts/agent/templates/ingress.yaml
@@ -30,9 +30,7 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-            {{- with .pathType }}
-            pathType: {{ . }}
-            {{- end }}
+            pathType: {{ .pathType | default "ImplementationSpecific" }}
             backend:
               service:
                 name: {{ include "agent.fullname" $ }}

--- a/charts/agent/templates/ingress.yaml
+++ b/charts/agent/templates/ingress.yaml
@@ -20,7 +20,7 @@ spec:
         {{- range .hosts }}
         - {{ . | quote }}
         {{- end }}
-      secretName: {{ .secretName }}
+      secretName: {{ .secretName | quote }}
     {{- end }}
   {{- end }}
   rules:
@@ -29,7 +29,7 @@ spec:
       http:
         paths:
           {{- range .paths }}
-          - path: {{ .path }}
+          - path: {{ .path | quote }}
             pathType: {{ .pathType | default "ImplementationSpecific" }}
             backend:
               service:

--- a/charts/agent/templates/service.yaml
+++ b/charts/agent/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "agent.fullname" . }}
+  labels:
+    {{- include "agent.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "agent.selectorLabels" . | nindent 4 }}

--- a/charts/agent/templates/serviceaccount.yaml
+++ b/charts/agent/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "agent.serviceAccountName" . }}
+  labels:
+    {{- include "agent.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/agent/templates/tests/test-connection.yaml
+++ b/charts/agent/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "agent.fullname" . }}-test-connection"
+  labels:
+    {{- include "agent.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "agent.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -13,7 +13,7 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
-# This is for the secretes for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+# This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []
 # This is to override the chart name.
 nameOverride: ""

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -38,16 +38,20 @@ podAnnotations: {}
 # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 podLabels: {}
 
-podSecurityContext: {}
-  # fsGroup: 2000
+podSecurityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext:
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  seccompProfile:
+    type: RuntimeDefault
+  capabilities:
+    drop:
+      - ALL
 
 # This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
 service:

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -1,0 +1,123 @@
+# Default values for agent.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
+replicaCount: 1
+
+# This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
+image:
+  repository: nginx
+  # This sets the pull policy for images.
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+# This is for the secretes for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: []
+# This is to override the chart name.
+nameOverride: ""
+fullnameOverride: ""
+
+# This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# This is for setting Kubernetes Annotations to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+# This is for setting Kubernetes Labels to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+# This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
+service:
+  # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+  type: ClusterIP
+  # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
+  port: 80
+
+# This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+
+# This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/src/gantry/highlight.py
+++ b/src/gantry/highlight.py
@@ -1,0 +1,93 @@
+import logging
+from pygments.lexers import get_lexer_by_name
+from pygments.lexer import RegexLexer
+from pygments.token import Keyword, Name, String, Number, Comment, Operator, Punctuation, Whitespace
+from rich.text import Text
+
+logger = logging.getLogger(__name__)
+
+
+class GoTemplateLexer(RegexLexer):
+    """Lexer for Go text/html templates with YAML."""
+    name = "Go Template"
+    aliases = ["gotmpl"]
+    filenames = ["*.tpl"]
+
+    tokens = {
+        "root": [
+            (r"\{\{-?", Punctuation),
+            (r"-?\}\}", Punctuation),
+            (r"\b(if|else|end|range|define|template|block|with)\b", Keyword),
+            (r"\b(and|or|not|eq|ne|lt|le|gt|ge|call|html|js|index|len|slice|print|printf|println|urlquery)\b", Name.Builtin),
+            (r"\$\w+", Name.Variable),
+            (r"\.\w+", Name.Attribute),
+            (r"\"[^\"]*\"", String.Double),
+            (r"'[^']*'", String.Single),
+            (r"-?\d+\.\d+", Number.Float),
+            (r"-?\d+", Number.Integer),
+            (r"\b(true|false|nil)\b", Keyword.Constant),
+            (r"[|:=]", Operator),
+            (r"#.*$", Comment.Single),
+            (r"\s+", Whitespace),
+            (r".", Whitespace),
+        ]
+    }
+
+
+def _tokens_to_rich(tokens: list) -> Text:
+    """Convert Pygments tokens to Rich.Text object."""
+    text = Text()
+    token_styles = {
+        Keyword: "bold cyan",
+        Keyword.Constant: "bold magenta",
+        Name.Builtin: "bold yellow",
+        Name.Variable: "green",
+        Name.Attribute: "magenta",
+        String: "green",
+        String.Double: "green",
+        String.Single: "green",
+        Number: "cyan",
+        Number.Integer: "cyan",
+        Number.Float: "cyan",
+        Comment: "dim white",
+        Comment.Single: "dim white",
+        Operator: "white",
+        Punctuation: "white",
+    }
+
+    for token_type, value in tokens:
+        # Find style: check exact match, then parent types
+        style = None
+        for tok_type, rich_style in token_styles.items():
+            if token_type == tok_type or token_type in tok_type:
+                style = rich_style
+                break
+
+        if style and value.strip():
+            text.append(value, style=style)
+        else:
+            text.append(value)
+
+    return text
+
+
+def highlight_yaml(content: str) -> Text:
+    """Syntax highlight YAML using Pygments."""
+    try:
+        lexer = get_lexer_by_name("yaml")
+        tokens = list(lexer.get_tokens(content))
+        return _tokens_to_rich(tokens)
+    except Exception as e:
+        logger.warning(f"YAML highlighting failed: {e}")
+        return Text(content)
+
+
+def highlight_go_template(content: str) -> Text:
+    """Syntax highlight Go template using Pygments."""
+    try:
+        lexer = GoTemplateLexer()
+        tokens = list(lexer.get_tokens(content))
+        return _tokens_to_rich(tokens)
+    except Exception as e:
+        logger.warning(f"Go template highlighting failed: {e}")
+        return Text(content)

--- a/src/gantry/highlight.py
+++ b/src/gantry/highlight.py
@@ -8,7 +8,7 @@ from rich.text import Text
 logger = logging.getLogger(__name__)
 
 # Theme name: configurable per user preference
-THEME = "monokai"
+THEME = "zenburn"  # Default theme, can be changed via set_theme()
 
 # Cache for style lookups
 _style_cache = {}

--- a/src/gantry/highlight.py
+++ b/src/gantry/highlight.py
@@ -1,10 +1,17 @@
 import logging
 from pygments.lexers import get_lexer_by_name
 from pygments.lexer import RegexLexer
-from pygments.token import Keyword, Name, String, Number, Comment, Operator, Punctuation, Whitespace
+from pygments.token import Keyword, Name, String, Number, Comment, Operator, Punctuation, Whitespace, Token
+from pygments.styles import get_style_by_name
 from rich.text import Text
 
 logger = logging.getLogger(__name__)
+
+# Theme name: configurable per user preference
+THEME = "monokai"
+
+# Cache for style lookups
+_style_cache = {}
 
 
 class GoTemplateLexer(RegexLexer):
@@ -34,36 +41,41 @@ class GoTemplateLexer(RegexLexer):
     }
 
 
+def _get_rich_style(token_type) -> str:
+    """Map Pygments token type to Rich style using theme."""
+    if token_type in _style_cache:
+        return _style_cache[token_type]
+
+    try:
+        style_obj = get_style_by_name(THEME)
+        style_dict = style_obj.style_for_token(token_type)
+
+        # Convert Pygments style to Rich style string
+        parts = []
+        if style_dict["bold"]:
+            parts.append("bold")
+        if style_dict["italic"]:
+            parts.append("italic")
+        if style_dict["underline"]:
+            parts.append("underline")
+        if style_dict["color"]:
+            parts.append(f"#{style_dict['color']}")
+
+        rich_style = " ".join(parts) if parts else "white"
+        _style_cache[token_type] = rich_style
+        return rich_style
+    except Exception:
+        _style_cache[token_type] = "white"
+        return "white"
+
+
 def _tokens_to_rich(tokens: list) -> Text:
-    """Convert Pygments tokens to Rich.Text object."""
+    """Convert Pygments tokens to Rich.Text object using current theme."""
     text = Text()
-    token_styles = {
-        Keyword: "bold cyan",
-        Keyword.Constant: "bold magenta",
-        Name.Builtin: "bold yellow",
-        Name.Variable: "green",
-        Name.Attribute: "magenta",
-        String: "green",
-        String.Double: "green",
-        String.Single: "green",
-        Number: "cyan",
-        Number.Integer: "cyan",
-        Number.Float: "cyan",
-        Comment: "dim white",
-        Comment.Single: "dim white",
-        Operator: "white",
-        Punctuation: "white",
-    }
 
     for token_type, value in tokens:
-        # Find style: check exact match, then parent types
-        style = None
-        for tok_type, rich_style in token_styles.items():
-            if token_type == tok_type or token_type in tok_type:
-                style = rich_style
-                break
-
-        if style and value.strip():
+        style = _get_rich_style(token_type)
+        if value.strip():
             text.append(value, style=style)
         else:
             text.append(value)
@@ -91,3 +103,20 @@ def highlight_go_template(content: str) -> Text:
     except Exception as e:
         logger.warning(f"Go template highlighting failed: {e}")
         return Text(content)
+
+
+def set_theme(theme_name: str) -> None:
+    """Set syntax highlighting theme. Available: monokai, dracula, nord, etc."""
+    global THEME
+    try:
+        get_style_by_name(theme_name)
+        THEME = theme_name
+        _style_cache.clear()
+        logger.debug(f"Switched to theme: {theme_name}")
+    except Exception as e:
+        logger.error(f"Theme '{theme_name}' not found: {e}")
+
+
+def get_theme() -> str:
+    """Get current syntax highlighting theme."""
+    return THEME

--- a/src/gantry/highlight.py
+++ b/src/gantry/highlight.py
@@ -3,6 +3,7 @@ from pygments.lexers import get_lexer_by_name
 from pygments.lexer import RegexLexer
 from pygments.token import Keyword, Name, String, Number, Comment, Operator, Punctuation, Whitespace, Token, Text as PygmentsText
 from pygments.styles import get_style_by_name
+from pygments.util import ClassNotFound
 from rich.text import Text
 
 logger = logging.getLogger(__name__)
@@ -69,7 +70,7 @@ def _get_rich_style(token_type) -> str:
         rich_style = " ".join(parts) if parts else "white"
         _style_cache[token_type] = rich_style
         return rich_style
-    except Exception:
+    except (ClassNotFound, KeyError, AttributeError, ValueError):
         _style_cache[token_type] = "white"
         return "white"
 
@@ -94,7 +95,7 @@ def highlight_yaml(content: str) -> Text:
         lexer = get_lexer_by_name("yaml")
         tokens = list(lexer.get_tokens(content))
         return _tokens_to_rich(tokens)
-    except Exception as e:
+    except (ClassNotFound, ValueError, TypeError) as e:
         logger.warning(f"YAML highlighting failed: {e}")
         return Text(content)
 
@@ -105,7 +106,7 @@ def highlight_go_template(content: str) -> Text:
         lexer = GoTemplateLexer()
         tokens = list(lexer.get_tokens(content))
         return _tokens_to_rich(tokens)
-    except Exception as e:
+    except (ValueError, TypeError) as e:
         logger.warning(f"Go template highlighting failed: {e}")
         return Text(content)
 
@@ -118,7 +119,7 @@ def set_theme(theme_name: str) -> None:
         THEME = theme_name
         _style_cache.clear()
         logger.debug(f"Switched to theme: {theme_name}")
-    except Exception as e:
+    except ClassNotFound as e:
         logger.error(f"Theme '{theme_name}' not found: {e}")
 
 

--- a/src/gantry/highlight.py
+++ b/src/gantry/highlight.py
@@ -1,7 +1,7 @@
 import logging
 from pygments.lexers import get_lexer_by_name
 from pygments.lexer import RegexLexer
-from pygments.token import Keyword, Name, String, Number, Comment, Operator, Punctuation, Whitespace, Token
+from pygments.token import Keyword, Name, String, Number, Comment, Operator, Punctuation, Whitespace, Token, Text as PygmentsText
 from pygments.styles import get_style_by_name
 from rich.text import Text
 
@@ -22,8 +22,14 @@ class GoTemplateLexer(RegexLexer):
 
     tokens = {
         "root": [
-            (r"\{\{-?", Punctuation),
-            (r"-?\}\}", Punctuation),
+            (r"\{\{-?", Punctuation, "template"),
+            (r"#[^\n]*", Comment.Single),
+            (r"[^\{#]+", PygmentsText),
+            (r"\{(?!\{)", PygmentsText),
+            (r".", PygmentsText),
+        ],
+        "template": [
+            (r"-?\}\}", Punctuation, "#pop"),
             (r"\b(if|else|end|range|define|template|block|with)\b", Keyword),
             (r"\b(and|or|not|eq|ne|lt|le|gt|ge|call|html|js|index|len|slice|print|printf|println|urlquery)\b", Name.Builtin),
             (r"\$\w+", Name.Variable),
@@ -34,10 +40,9 @@ class GoTemplateLexer(RegexLexer):
             (r"-?\d+", Number.Integer),
             (r"\b(true|false|nil)\b", Keyword.Constant),
             (r"[|:=]", Operator),
-            (r"#.*$", Comment.Single),
             (r"\s+", Whitespace),
-            (r".", Whitespace),
-        ]
+            (r".", PygmentsText),
+        ],
     }
 
 

--- a/src/gantry/screens.py
+++ b/src/gantry/screens.py
@@ -1130,9 +1130,14 @@ class HelmScreen(Screen):
         border-right: solid $accent;
         background: $panel;
     }
-    #yaml-preview {
+    #preview-container {
         width: 70%;
         height: 100%;
+    }
+    #yaml-preview {
+        width: 100%;
+        height: 100%;
+        overflow: auto;
     }
     """
 
@@ -1145,8 +1150,8 @@ class HelmScreen(Screen):
         """Compose the two-panel filesystem browser layout."""
         with Horizontal(id="helm-container"):
             yield DirectoryTree(Path.cwd(), id="file-tree")
-            yield TextArea("", language="yaml", theme="monokai",
-                           read_only=True, id="yaml-preview")
+            with ScrollableContainer(id="preview-container"):
+                yield Static("", id="yaml-preview")
         yield StatusBar(id="status-bar")
         yield KeybindingsBar(id="keybindings-bar")
 
@@ -1156,7 +1161,7 @@ class HelmScreen(Screen):
         """Load selected file content into the preview pane with syntax highlighting."""
         path = event.path
         status_bar = self.query_one("#status-bar", StatusBar)
-        text_area = self.query_one("#yaml-preview", TextArea)
+        preview = self.query_one("#yaml-preview", Static)
         try:
             size = path.stat().st_size
         except OSError as e:
@@ -1165,8 +1170,7 @@ class HelmScreen(Screen):
             return
         if size > self._MAX_PREVIEW_BYTES:
             status_bar.update_status(f"Skipped large file {path.name} ({size:,} bytes)")
-            text_area.load_text(f"<file too large to preview: {size:,} bytes>")
-            text_area.language = None
+            preview.update(f"<file too large to preview: {size:,} bytes>")
             return
         try:
             content = path.read_text(errors="replace")
@@ -1174,15 +1178,28 @@ class HelmScreen(Screen):
             logger.error("Failed to read file %s: %s", path, e)
             status_bar.update_status(f"Error reading file: {e}")
             return
-        status_bar.update_status(f"Loaded {path.name}")
-        text_area.load_text(content)
+
         suffix = path.suffix.lower()
-        if suffix in (".yaml", ".yml"):
-            text_area.language = "yaml"
-        elif suffix == ".json":
-            text_area.language = "json"
-        else:
-            text_area.language = None
+        is_template = suffix == ".tpl" or (
+            suffix in (".yaml", ".yml") and "templates" in path.parts
+        )
+
+        status_bar.update_status(f"Loaded {path.name}")
+
+        try:
+            if is_template:
+                from gantry.highlight import highlight_go_template
+                highlighted = highlight_go_template(content)
+                preview.update(highlighted)
+            elif suffix in (".yaml", ".yml"):
+                from gantry.highlight import highlight_yaml
+                highlighted = highlight_yaml(content)
+                preview.update(highlighted)
+            else:
+                preview.update(content)
+        except Exception as e:
+            logger.warning(f"Failed to highlight file: {e}")
+            preview.update(content)
 
     def action_refresh(self) -> None:
         """Reload the directory tree from disk."""

--- a/src/gantry/screens.py
+++ b/src/gantry/screens.py
@@ -1151,7 +1151,7 @@ class HelmScreen(Screen):
         with Horizontal(id="helm-container"):
             yield DirectoryTree(Path.cwd(), id="file-tree")
             with ScrollableContainer(id="preview-container"):
-                yield Static("", id="yaml-preview")
+                yield Static("", id="yaml-preview", markup=False)
         yield StatusBar(id="status-bar")
         yield KeybindingsBar(id="keybindings-bar")
 


### PR DESCRIPTION
## Summary

Implement proper syntax highlighting for Helm chart templates and YAML files in HelmScreen using Pygments lexers.

- Custom GoTemplateLexer for Go template syntax ({{ }}, keywords, properties, pipes)
- Built-in YAML lexer for YAML files
- 49 themes supported (monokai, dracula, nord, solarized-dark, etc)
- Theme switching via `set_theme()` API

## Test Plan

- [ ] Run app, open Helm screen
- [ ] Select YAML file → verify syntax coloring applied
- [ ] Select .tpl file → verify Go template tokens highlighted
- [ ] Test theme switching: `set_theme("dracula")`
- [ ] Verify no crashes on file selection
- [ ] Check that non-template files fall back gracefully

## Closes #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a complete Helm chart for the agent (chart metadata, defaults, service, ingress, autoscaling, service account, install test).
  * Improved file preview: fills available space, scrolls, and shows syntax-highlighted templates/YAML; oversized files show “too large to preview” and failures fall back to raw content.

* **Documentation**
  * Added post-install deployment access instructions shown after installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->