### PR TITLE
feat: add escape key to unload file in Helm screen

### DIFF
--- a/src/gantry/screens.py
+++ b/src/gantry/screens.py
@@ -1195,6 +1195,9 @@ class HelmScreen(Screen):
         if size > self._MAX_PREVIEW_BYTES:
             status_bar.update_status(f"Skipped large file {path.name} ({size:,} bytes)")
             preview.update(f"<file too large to preview: {size:,} bytes>")
+            self._file_loaded = True
+            bar = self.query_one("#keybindings-bar", KeybindingsBar)
+            bar.update_context("helm", "tree", detail_open=False, search_active=False, helm_preview_open=True)
             return
         try:
             content = path.read_text(errors="replace")
@@ -1227,7 +1230,7 @@ class HelmScreen(Screen):
 
         self._file_loaded = True
         bar = self.query_one("#keybindings-bar", KeybindingsBar)
-        bar.update_context("helm", "tree", detail_open=True, search_active=False)
+        bar.update_context("helm", "tree", detail_open=False, search_active=False, helm_preview_open=True)
 
     def action_escape(self) -> None:
         """Clear the preview pane and refocus the file tree."""
@@ -1237,7 +1240,7 @@ class HelmScreen(Screen):
         self.query_one("#status-bar", StatusBar).update_status("")
         self._file_loaded = False
         bar = self.query_one("#keybindings-bar", KeybindingsBar)
-        bar.update_context("helm", "tree", detail_open=False, search_active=False)
+        bar.update_context("helm", "tree", detail_open=False, search_active=False, helm_preview_open=False)
         self.query_one("#file-tree", DirectoryTree).focus()
 
     def action_refresh(self) -> None:

--- a/src/gantry/screens.py
+++ b/src/gantry/screens.py
@@ -11,7 +11,7 @@ from textual.widget import Widget
 from textual.binding import Binding
 from textual.message import Message
 from textual import work
-from textual.reactive import reactive
+from textual.reactive import Reactive, reactive
 from textual.css.query import NoMatches
 import json
 
@@ -1116,9 +1116,11 @@ class HelmScreen(Screen):
     BINDINGS = [
         ("tab", "app.action_switch_screen", "Cluster View"),
         ("r", "refresh", "Refresh"),
+        ("escape", "escape", "Clear preview"),
         ("q", "quit", "Quit"),
     ]
 
+    _file_loaded: Reactive[bool] = reactive(False)
     _MAX_PREVIEW_BYTES = 1_000_000  # 1 MB
 
     CSS = """
@@ -1161,6 +1163,12 @@ class HelmScreen(Screen):
         """Initialize HelmScreen and set keybindings context."""
         bar = self.query_one("#keybindings-bar", KeybindingsBar)
         bar.update_context("helm", "tree", detail_open=False, search_active=False)
+
+    def check_action(self, action: str, parameters: tuple) -> bool | None:
+        """Disable escape action when no file is loaded."""
+        if action == "escape":
+            return self._file_loaded or None
+        return True
 
     def compose(self):
         """Compose the two-panel filesystem browser layout."""
@@ -1216,6 +1224,21 @@ class HelmScreen(Screen):
         except Exception as e:
             logger.warning(f"Failed to highlight file: {e}")
             preview.update(content)
+
+        self._file_loaded = True
+        bar = self.query_one("#keybindings-bar", KeybindingsBar)
+        bar.update_context("helm", "tree", detail_open=True, search_active=False)
+
+    def action_escape(self) -> None:
+        """Clear the preview pane and refocus the file tree."""
+        if not self._file_loaded:
+            return
+        self.query_one("#yaml-preview", Static).update("")
+        self.query_one("#status-bar", StatusBar).update_status("")
+        self._file_loaded = False
+        bar = self.query_one("#keybindings-bar", KeybindingsBar)
+        bar.update_context("helm", "tree", detail_open=False, search_active=False)
+        self.query_one("#file-tree", DirectoryTree).focus()
 
     def action_refresh(self) -> None:
         """Reload the directory tree from disk."""

--- a/src/gantry/widgets.py
+++ b/src/gantry/widgets.py
@@ -305,16 +305,18 @@ class KeybindingsBar(Static):
         - current_panel: Focused panel (tracked for future context-aware hints)
         - detail_panel_open: Whether detail panel is open
         - search_active: Whether search is active
+        - helm_preview_open: Whether the Helm file preview is showing content
         """
         super().__init__(*args, **kwargs)
         self.screen_type = "cluster"  # "cluster" or "helm"
         self.current_panel = "sidebar"  # "sidebar", "table", "detail", "search"
         self.detail_panel_open = False
         self.search_active = False
+        self.helm_preview_open = False
         # Render initial content immediately so Static has something to show on first paint
         self.update(self._build_text())
 
-    def update_context(self, screen_type: str, current_panel: str, detail_open: bool, search_active: bool) -> None:
+    def update_context(self, screen_type: str, current_panel: str, detail_open: bool, search_active: bool, helm_preview_open: bool = False) -> None:
         """Update the context state and refresh the display.
 
         Args:
@@ -322,16 +324,18 @@ class KeybindingsBar(Static):
             current_panel: "sidebar", "table", "detail", or "search" (tracked for future context-aware enhancements)
             detail_open: whether detail panel is open
             search_active: whether search is active
+            helm_preview_open: whether the Helm file preview pane is showing content
         """
         self.screen_type = screen_type
         self.current_panel = current_panel
         self.detail_panel_open = detail_open
         self.search_active = search_active
+        self.helm_preview_open = helm_preview_open
         self.update(self._build_text())
 
     def _build_text(self) -> str:
         """Build keybindings string based on current context."""
-        # Case 1: Detail panel open
+        # Case 1: Detail panel open (cluster screen)
         if self.detail_panel_open:
             return "← Back | → Forward | Esc Close | ↑↓ Scroll"
 
@@ -339,7 +343,11 @@ class KeybindingsBar(Static):
         if self.search_active:
             return "Esc Cancel | ↵ Select"
 
-        # Case 3 & 4: Normal state (depends on screen type)
+        # Case 3: Helm screen with file preview showing
+        if self.screen_type == "helm" and self.helm_preview_open:
+            return "↑↓ Navigate | ↵ Expand | Esc Clear preview | r Refresh | Tab Cluster | q Quit"
+
+        # Case 4 & 5: Normal state (depends on screen type)
         if self.screen_type == "cluster":
             return "←→ Navigate | d Describe | l Logs | r Refresh | c Context | / Search | Tab Helm | q Quit"
         elif self.screen_type == "helm":


### PR DESCRIPTION
## Summary

Add Esc keybinding to Helm screen that clears the file preview pane, blanks the status bar, and refocuses the file tree. The Esc hint only appears in the keybindings bar when a file is loaded.

## Implementation

- Add `_file_loaded: Reactive[bool]` state to track when file is selected
- Add `("escape", "escape", "Clear preview")` to BINDINGS
- Implement `check_action()` to gate Esc availability based on `_file_loaded`
- Update `on_directory_tree_file_selected()` to set state and show Esc hint
- Add `action_escape()` to clear preview, blank status, hide hint, and refocus tree

## Testing

- All 31 Helm tests pass
- App starts correctly with --debug flag
- Manual test: select file → Esc clears + refocuses tree

## Related

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Press Escape to close the Helm file preview and return focus to the file tree
  * Keybindings bar now displays context-aware actions that dynamically reflect the current preview state

<!-- end of auto-generated comment: release notes by coderabbit.ai -->