### PR TITLE
feat: Advanced filters for cluster resources (issue #48)

### DIFF
--- a/src/gantry/k8s.py
+++ b/src/gantry/k8s.py
@@ -1201,7 +1201,7 @@ def _make_filter_predicate(term: str) -> Callable[[Dict[str, Any]], bool]:
         if field == "name":
             if value.startswith("/") and value.endswith("/") and len(value) > 2:
                 try:
-                    pattern = re.compile(value[1:-1])
+                    pattern = re.compile(value[1:-1], re.IGNORECASE)
                     return lambda r, p=pattern: bool(p.search(str(r.get("name", ""))))
                 except re.error:
                     pass
@@ -1217,12 +1217,15 @@ def _make_filter_predicate(term: str) -> Callable[[Dict[str, Any]], bool]:
                     if op == "<":
                         return lambda r, c=cutoff: (r.get("age_seconds") or 0) > c
                     return lambda r, c=cutoff: 0 < (r.get("age_seconds") or 0) < c
-        return lambda r: True
+            # Malformed age expression — don't match anything.
+            return lambda r: False
+        # Unknown field — don't match anything.
+        return lambda r: False
 
     # No colon: regex if wrapped in /…/, otherwise substring across all string fields
     if term.startswith("/") and term.endswith("/") and len(term) > 2:
         try:
-            pattern = re.compile(term[1:-1])
+            pattern = re.compile(term[1:-1], re.IGNORECASE)
             return lambda r, p=pattern: any(
                 bool(p.search(str(v)))
                 for k, v in r.items()

--- a/src/gantry/k8s.py
+++ b/src/gantry/k8s.py
@@ -209,6 +209,8 @@ def list_services(namespace: str = "default", context: Optional[str] = None) -> 
                 "cluster_ip": svc.spec.cluster_ip,
                 "external_ips": svc.spec.external_i_ps or [],
                 "ports": ports,
+                "_labels": svc.metadata.labels or {},
+                "_annotations": svc.metadata.annotations or {},
             })
         logger.debug(f"list_services returned {len(result)} services for namespace={namespace}")
         return result
@@ -301,6 +303,8 @@ def list_configmaps(namespace: str = "default", context: Optional[str] = None) -
                 "namespace": cm.metadata.namespace,
                 "keys": data_keys,
                 "key_count": len(data_keys),
+                "_labels": cm.metadata.labels or {},
+                "_annotations": cm.metadata.annotations or {},
             })
         logger.debug(f"list_configmaps returned {len(result)} configmaps for namespace={namespace}")
         return result
@@ -337,6 +341,8 @@ def list_replicasets(namespace: str = "default", context: Optional[str] = None) 
                 "desired": rs.spec.replicas or 0,
                 "ready": rs.status.ready_replicas or 0,
                 "available": rs.status.available_replicas or 0,
+                "_labels": rs.metadata.labels or {},
+                "_annotations": rs.metadata.annotations or {},
             })
         logger.debug(f"list_replicasets returned {len(result)} replicasets for namespace={namespace}")
         return result
@@ -372,6 +378,8 @@ def list_statefulsets(namespace: str = "default", context: Optional[str] = None)
                 "namespace": ss.metadata.namespace,
                 "ready": f"{ss.status.ready_replicas or 0}/{ss.spec.replicas or 0}",
                 "age": ss.metadata.creation_timestamp.isoformat() if ss.metadata.creation_timestamp else "",
+                "_labels": ss.metadata.labels or {},
+                "_annotations": ss.metadata.annotations or {},
             })
         logger.debug(f"list_statefulsets returned {len(result)} statefulsets for namespace={namespace}")
         return result
@@ -408,6 +416,8 @@ def list_daemonsets(namespace: str = "default", context: Optional[str] = None) -
                 "desired": ds.status.desired_number_scheduled or 0,
                 "ready": ds.status.number_ready or 0,
                 "node_selector": str(ds.spec.template.spec.node_selector or {}),
+                "_labels": ds.metadata.labels or {},
+                "_annotations": ds.metadata.annotations or {},
             })
         logger.debug(f"list_daemonsets returned {len(result)} daemonsets for namespace={namespace}")
         return result
@@ -456,6 +466,8 @@ def list_jobs(namespace: str = "default", context: Optional[str] = None) -> List
                 "completions": f"{succeeded}/{completions}",
                 "duration": str(job.status.completion_time - job.status.start_time) if (job.status.completion_time and job.status.start_time) else "N/A",
                 "status": job_status,
+                "_labels": job.metadata.labels or {},
+                "_annotations": job.metadata.annotations or {},
             })
         logger.debug(f"list_jobs returned {len(result)} jobs for namespace={namespace}")
         return result
@@ -492,6 +504,8 @@ def list_cronjobs(namespace: str = "default", context: Optional[str] = None) -> 
                 "schedule": cj.spec.schedule,
                 "last_run": cj.status.last_schedule_time.isoformat() if cj.status.last_schedule_time else "Never",
                 "active": len(cj.status.active or []),
+                "_labels": cj.metadata.labels or {},
+                "_annotations": cj.metadata.annotations or {},
             })
         logger.debug(f"list_cronjobs returned {len(result)} cronjobs for namespace={namespace}")
         return result
@@ -537,6 +551,8 @@ def list_ingresses(namespace: str = "default", context: Optional[str] = None) ->
                 "class": ingress_class,
                 "hosts": hosts,
                 "address": address,
+                "_labels": ing.metadata.labels or {},
+                "_annotations": ing.metadata.annotations or {},
             })
         logger.debug(f"list_ingresses returned {len(result)} ingresses for namespace={namespace}")
         return result
@@ -571,6 +587,8 @@ def list_endpoints(namespace: str = "default", context: Optional[str] = None) ->
                 "name": ep.metadata.name,
                 "namespace": ep.metadata.namespace,
                 "endpoints": str(len(ep.subsets or [])),
+                "_labels": ep.metadata.labels or {},
+                "_annotations": ep.metadata.annotations or {},
             })
         logger.debug(f"list_endpoints returned {len(result)} endpoints for namespace={namespace}")
         return result
@@ -606,6 +624,8 @@ def list_secrets(namespace: str = "default", context: Optional[str] = None) -> L
                 "namespace": secret.metadata.namespace,
                 "type": secret.type or "",
                 "keys": len(secret.data or {}),
+                "_labels": secret.metadata.labels or {},
+                "_annotations": secret.metadata.annotations or {},
             })
         logger.debug(f"list_secrets returned {len(result)} secrets for namespace={namespace}")
         return result
@@ -645,6 +665,8 @@ def list_persistentvolumeclaims(namespace: str = "default", context: Optional[st
                 "status": pvc.status.phase or "",
                 "volume": pvc.spec.volume_name or "",
                 "capacity": capacity,
+                "_labels": pvc.metadata.labels or {},
+                "_annotations": pvc.metadata.annotations or {},
             })
         logger.debug(f"list_persistentvolumeclaims returned {len(result)} pvcs for namespace={namespace}")
         return result
@@ -680,6 +702,8 @@ def list_persistentvolumes(context: Optional[str] = None) -> List[Dict[str, Any]
                 "capacity": capacity,
                 "access_modes": ",".join(pv.spec.access_modes or []),
                 "status": pv.status.phase or "",
+                "_labels": pv.metadata.labels or {},
+                "_annotations": pv.metadata.annotations or {},
             })
         logger.debug(f"list_persistentvolumes returned {len(result)} pvs")
         return result
@@ -711,6 +735,8 @@ def list_namespace_resources(context: Optional[str] = None) -> List[Dict[str, An
                 "namespace": "",
                 "status": ns.status.phase or "",
                 "age": ns.metadata.creation_timestamp.isoformat() if ns.metadata.creation_timestamp else "",
+                "_labels": ns.metadata.labels or {},
+                "_annotations": ns.metadata.annotations or {},
             })
         logger.debug(f"list_namespace_resources returned {len(result)} namespaces")
         return result
@@ -755,6 +781,8 @@ def list_nodes(context: Optional[str] = None) -> List[Dict[str, Any]]:
                 "status": node_status,
                 "roles": roles or "none",
                 "version": version,
+                "_labels": node.metadata.labels or {},
+                "_annotations": node.metadata.annotations or {},
             })
         logger.debug(f"list_nodes returned {len(result)} nodes")
         return result
@@ -1161,12 +1189,23 @@ def get_pod_logs(
 
 
 def _parse_duration(duration_str: str) -> Optional[int]:
-    """Parse a duration string like '1h', '30m', '2d' into seconds."""
+    """Parse a duration string into seconds. Supports '1h', '1h30m', '90s', '90' (bare int = seconds)."""
     units = {"s": 1, "m": 60, "h": 3600, "d": 86400}
-    match = re.fullmatch(r"(\d+)([smhd])", duration_str.strip().lower())
-    if not match:
+    s = duration_str.strip().lower()
+    if s.isdigit():
+        return int(s)
+    total = 0
+    matched = False
+    for m in re.finditer(r"(\d+(?:\.\d+)?)([smhd])", s):
+        matched = True
+        total += int(float(m.group(1)) * units[m.group(2)])
+    if not matched:
         return None
-    return int(match.group(1)) * units[match.group(2)]
+    # Reject if there's non-whitespace left over after removing all valid segments
+    leftover = re.sub(r"\d+(?:\.\d+)?[smhd]", "", s).strip()
+    if leftover:
+        return None
+    return total
 
 
 def _make_filter_predicate(term: str) -> Callable[[Dict[str, Any]], bool]:
@@ -1216,7 +1255,7 @@ def _make_filter_predicate(term: str) -> Callable[[Dict[str, Any]], bool]:
                     cutoff = now - secs
                     if op == "<":
                         return lambda r, c=cutoff: (r.get("age_seconds") or 0) > c
-                    return lambda r, c=cutoff: 0 < (r.get("age_seconds") or 0) < c
+                    return lambda r, c=cutoff: (r.get("age_seconds") or 0) < c
             # Malformed age expression — don't match anything.
             return lambda r: False
         # Unknown field — don't match anything.

--- a/src/gantry/k8s.py
+++ b/src/gantry/k8s.py
@@ -2,7 +2,9 @@
 
 import logging
 import os
-from typing import Any, Dict, List, Optional
+import re
+import time
+from typing import Any, Callable, Dict, List, Optional
 
 import yaml
 
@@ -150,6 +152,8 @@ def list_pods(namespace: str = "default", context: Optional[str] = None) -> List
                     if pod.metadata.creation_timestamp
                     else None
                 ),
+                "_labels": pod.metadata.labels or {},
+                "_annotations": pod.metadata.annotations or {},
             })
         logger.debug(f"list_pods returned {len(result)} pods for namespace={namespace}")
         return result
@@ -251,6 +255,8 @@ def list_deployments(namespace: str = "default", context: Optional[str] = None) 
                 "updated_replicas": deploy.status.updated_replicas or 0,
                 "available_replicas": deploy.status.available_replicas or 0,
                 "strategy_type": deploy.spec.strategy.type if deploy.spec.strategy else None,
+                "_labels": deploy.metadata.labels or {},
+                "_annotations": deploy.metadata.annotations or {},
             })
         logger.debug(f"list_deployments returned {len(result)} deployments for namespace={namespace}")
         return result
@@ -1152,3 +1158,117 @@ def get_pod_logs(
     except Exception as e:
         logger.error(f"Error in get_pod_logs: {e}", exc_info=True)
         return f"Error: {str(e)}"
+
+
+def _parse_duration(duration_str: str) -> Optional[int]:
+    """Parse a duration string like '1h', '30m', '2d' into seconds."""
+    units = {"s": 1, "m": 60, "h": 3600, "d": 86400}
+    match = re.fullmatch(r"(\d+)([smhd])", duration_str.strip().lower())
+    if not match:
+        return None
+    return int(match.group(1)) * units[match.group(2)]
+
+
+def _make_filter_predicate(term: str) -> Callable[[Dict[str, Any]], bool]:
+    """Parse a single filter term into a predicate function."""
+    term = term.strip()
+    if not term:
+        return lambda r: True
+
+    if ":" in term:
+        field, _, value = term.partition(":")
+        field = field.strip().lower()
+        value = value.strip()
+
+        if field == "label":
+            if "=" in value:
+                lk, _, lv = value.partition("=")
+                return lambda r, k=lk, v=lv: r.get("_labels", {}).get(k) == v
+            return lambda r, k=value: k in r.get("_labels", {})
+
+        if field == "annotation":
+            if "=" in value:
+                ak, _, av = value.partition("=")
+                return lambda r, k=ak, v=av: r.get("_annotations", {}).get(k) == v
+            return lambda r, k=value: k in r.get("_annotations", {})
+
+        if field == "status":
+            return lambda r, v=value: str(r.get("status", "")).lower() == v.lower()
+
+        if field == "namespace":
+            return lambda r, v=value: v.lower() in str(r.get("namespace", "")).lower()
+
+        if field == "name":
+            if value.startswith("/") and value.endswith("/") and len(value) > 2:
+                try:
+                    pattern = re.compile(value[1:-1])
+                    return lambda r, p=pattern: bool(p.search(str(r.get("name", ""))))
+                except re.error:
+                    pass
+            return lambda r, v=value: v.lower() in str(r.get("name", "")).lower()
+
+        if field == "age":
+            now = time.time()
+            if value and value[0] in ("<", ">"):
+                op = value[0]
+                secs = _parse_duration(value[1:])
+                if secs is not None:
+                    cutoff = now - secs
+                    if op == "<":
+                        return lambda r, c=cutoff: (r.get("age_seconds") or 0) > c
+                    return lambda r, c=cutoff: 0 < (r.get("age_seconds") or 0) < c
+        return lambda r: True
+
+    # No colon: regex if wrapped in /…/, otherwise substring across all string fields
+    if term.startswith("/") and term.endswith("/") and len(term) > 2:
+        try:
+            pattern = re.compile(term[1:-1])
+            return lambda r, p=pattern: any(
+                bool(p.search(str(v)))
+                for k, v in r.items()
+                if not k.startswith("_") and isinstance(v, str)
+            )
+        except re.error:
+            pass
+
+    return lambda r, t=term.lower(): any(
+        t in str(v).lower()
+        for k, v in r.items()
+        if not k.startswith("_") and isinstance(v, str)
+    )
+
+
+def filter_resources(resources: List[Dict[str, Any]], filter_expr: str) -> List[Dict[str, Any]]:
+    """
+    Filter resources by an expression string.
+
+    Syntax:
+        name:nginx            substring match on name
+        name:/nginx.*/        regex match on name
+        status:Running        exact status match (case-insensitive)
+        label:app=web         label key=value match
+        label:app             label key present
+        annotation:key=val    annotation match
+        namespace:kube-system namespace substring match
+        age:<1h               younger than 1 hour (s/m/h/d units)
+        age:>2d               older than 2 days
+        /pattern/             regex across all string fields
+
+    Combine terms with AND / OR (case-insensitive). AND binds tighter than OR.
+    Example: label:app=web AND status=Running OR name:nginx
+    """
+    if not filter_expr or not filter_expr.strip():
+        return resources
+
+    or_groups = re.split(r"\s+OR\s+", filter_expr, flags=re.IGNORECASE)
+    or_predicates: List[Callable[[Dict[str, Any]], bool]] = []
+    for group in or_groups:
+        and_terms = re.split(r"\s+AND\s+", group, flags=re.IGNORECASE)
+        preds = [_make_filter_predicate(t) for t in and_terms if t.strip()]
+        if preds:
+            or_predicates.append(lambda r, ps=preds: all(p(r) for p in ps))
+
+    if not or_predicates:
+        return resources
+
+    return [r for r in resources if any(p(r) for p in or_predicates)]

--- a/src/gantry/screens.py
+++ b/src/gantry/screens.py
@@ -16,7 +16,7 @@ from textual.css.query import NoMatches
 import json
 
 from gantry import k8s, state
-from gantry.widgets import ResourceTable, SearchInput, StatusBar, KeybindingsBar
+from gantry.widgets import ResourceTable, SearchInput, StatusBar, KeybindingsBar, FilterPanel
 
 logger = logging.getLogger(__name__)
 
@@ -198,6 +198,7 @@ class ClusterScreen(Screen):
         ("escape", "close_detail_panel", "Close Panel"),
         ("tab", "app.action_switch_screen", "Switch to Helm View"),
         Binding("slash", "focus_search", "Search", priority=True),
+        Binding("f", "focus_filter", "Filter", priority=True),
         ("c", "show_context_picker", "Pick Context"),
         ("d", "describe_resource", "Describe"),
         ("y", "show_yaml", "YAML"),
@@ -343,6 +344,10 @@ class ClusterScreen(Screen):
         self._yaml_full: str = ""
         self._yaml_spec: str = ""
         self._yaml_text_area: Optional[TextArea] = None
+        self._active_filter: str = ""
+        # _raw_resources stores all fetched resources for re-filtering;
+        # _resource_data stores what's currently displayed (matches table rows).
+        self._raw_resources: List[Dict[str, Any]] = []
 
     def compose(self):
         """Compose the cluster screen."""
@@ -371,6 +376,7 @@ class ClusterScreen(Screen):
             with Vertical(id="content-area"):
                 yield ResourceTable(id="resource-table")
                 yield SearchInput(id="search-input")
+                yield FilterPanel(id="filter-panel")
 
             # Detail panel for descriptions and logs (right sidebar)
             with VerticalScroll(id="detail-panel"):
@@ -646,9 +652,12 @@ class ClusterScreen(Screen):
         else:
             return
 
-        table.populate_resources(resources, columns, keys)
-        # Store resource data for actions like describe and logs
-        self._resource_data = resources
+        # Store raw resources for re-filtering when the expression changes.
+        self._raw_resources = resources
+        display_resources = k8s.filter_resources(resources, self._active_filter) if self._active_filter else resources
+        # _resource_data tracks what the table currently shows so cursor_row maps correctly.
+        self._resource_data = display_resources
+        table.populate_resources(display_resources, columns, keys)
 
     def on_list_view_highlighted(self, event: ListView.Highlighted) -> None:
         """Handle sidebar up/down navigation - immediately update resource type.
@@ -665,6 +674,125 @@ class ClusterScreen(Screen):
         search_input.add_class("show")
         search_input.focus()
         self.search_active = True
+
+    def action_focus_filter(self) -> None:
+        """Show and focus the advanced filter panel."""
+        filter_panel: FilterPanel = self.query_one("#filter-panel", FilterPanel)
+        filter_panel.add_class("show")
+        try:
+            inp = filter_panel.query_one("#filter-expr-input")
+            inp.focus()
+        except Exception:
+            filter_panel.focus()
+
+    def on_filter_panel_filter_changed(self, event: FilterPanel.FilterChanged) -> None:
+        """Apply the filter expression to the current resource data."""
+        self._active_filter = event.filter_expr
+        self._apply_active_filter()
+
+    def _apply_active_filter(self) -> None:
+        """Filter _raw_resources by _active_filter and repopulate the table."""
+        filtered = k8s.filter_resources(self._raw_resources, self._active_filter)
+        # Keep _resource_data in sync with what the table shows.
+        self._resource_data = filtered
+        try:
+            table: ResourceTable = self.query_one("#resource-table", ResourceTable)
+            columns, keys = self._get_columns_and_keys()
+            if columns:
+                table.populate_resources(filtered, columns, keys)
+        except Exception:
+            pass
+
+    def _get_columns_and_keys(self):
+        """Return (columns, keys) for the current resource type and namespace."""
+        resource_type = self.current_resource_type
+        is_all = self.current_namespace == "all"
+
+        mapping = {
+            "Pods": (
+                ["Name", "Namespace", "Status", "Ready", "Restarts"] if is_all
+                else ["Name", "Status", "Ready", "Restarts"],
+                ["name", "namespace", "status", "ready", "restarts"] if is_all
+                else ["name", "status", "ready", "restarts"],
+            ),
+            "Deployments": (
+                ["Name", "Namespace", "Replicas", "Ready", "Available"] if is_all
+                else ["Name", "Replicas", "Ready", "Available"],
+                ["name", "namespace", "replicas", "ready_replicas", "available_replicas"] if is_all
+                else ["name", "replicas", "ready_replicas", "available_replicas"],
+            ),
+            "ReplicaSets": (
+                ["Name", "Namespace", "Desired", "Ready", "Available"] if is_all
+                else ["Name", "Desired", "Ready", "Available"],
+                ["name", "namespace", "desired", "ready", "available"] if is_all
+                else ["name", "desired", "ready", "available"],
+            ),
+            "StatefulSets": (
+                ["Name", "Namespace", "Ready", "Age"] if is_all else ["Name", "Ready", "Age"],
+                ["name", "namespace", "ready", "age"] if is_all else ["name", "ready", "age"],
+            ),
+            "DaemonSets": (
+                ["Name", "Namespace", "Desired", "Ready", "Node Selector"] if is_all
+                else ["Name", "Desired", "Ready", "Node Selector"],
+                ["name", "namespace", "desired", "ready", "node_selector"] if is_all
+                else ["name", "desired", "ready", "node_selector"],
+            ),
+            "Jobs": (
+                ["Name", "Namespace", "Completions", "Duration", "Status"] if is_all
+                else ["Name", "Completions", "Duration", "Status"],
+                ["name", "namespace", "completions", "duration", "status"] if is_all
+                else ["name", "completions", "duration", "status"],
+            ),
+            "CronJobs": (
+                ["Name", "Namespace", "Schedule", "Last Run", "Active"] if is_all
+                else ["Name", "Schedule", "Last Run", "Active"],
+                ["name", "namespace", "schedule", "last_run", "active"] if is_all
+                else ["name", "schedule", "last_run", "active"],
+            ),
+            "Services": (
+                ["Name", "Namespace", "Type", "Cluster IP"] if is_all
+                else ["Name", "Type", "Cluster IP"],
+                ["name", "namespace", "type", "cluster_ip"] if is_all
+                else ["name", "type", "cluster_ip"],
+            ),
+            "Ingresses": (
+                ["Name", "Namespace", "Class", "Hosts", "Address"] if is_all
+                else ["Name", "Class", "Hosts", "Address"],
+                ["name", "namespace", "class", "hosts", "address"] if is_all
+                else ["name", "class", "hosts", "address"],
+            ),
+            "Endpoints": (
+                ["Name", "Namespace", "Endpoints"] if is_all else ["Name", "Endpoints"],
+                ["name", "namespace", "endpoints"] if is_all else ["name", "endpoints"],
+            ),
+            "ConfigMaps": (
+                ["Name", "Namespace", "Keys"] if is_all else ["Name", "Keys"],
+                ["name", "namespace", "key_count"] if is_all else ["name", "key_count"],
+            ),
+            "Secrets": (
+                ["Name", "Namespace", "Type", "Keys"] if is_all else ["Name", "Type", "Keys"],
+                ["name", "namespace", "type", "keys"] if is_all else ["name", "type", "keys"],
+            ),
+            "PersistentVolumeClaims": (
+                ["Name", "Namespace", "Status", "Volume", "Capacity"] if is_all
+                else ["Name", "Status", "Volume", "Capacity"],
+                ["name", "namespace", "status", "volume", "capacity"] if is_all
+                else ["name", "status", "volume", "capacity"],
+            ),
+            "PersistentVolumes": (
+                ["Name", "Capacity", "Access Modes", "Status"],
+                ["name", "capacity", "access_modes", "status"],
+            ),
+            "Namespaces": (
+                ["Name", "Status", "Age"],
+                ["name", "status", "age"],
+            ),
+            "Nodes": (
+                ["Name", "Status", "Roles", "Version"],
+                ["name", "status", "roles", "version"],
+            ),
+        }
+        return mapping.get(resource_type, ([], []))
 
     def action_describe_resource(self) -> None:
         """Describe the selected resource."""

--- a/src/gantry/screens.py
+++ b/src/gantry/screens.py
@@ -2,7 +2,7 @@
 
 import logging
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 from textual.screen import Screen, ModalScreen
 from textual.containers import Container, Vertical, Horizontal, ScrollableContainer, VerticalScroll
 from textual.widgets import Label, Static, Button, OptionList, Input, TextArea, ListView, ListItem, DirectoryTree
@@ -321,6 +321,105 @@ class ClusterScreen(Screen):
         "Nodes": "node",
     }
 
+    # Maps resource_type -> {"all": (columns, keys), "single": (columns, keys)}
+    # Used by both _display_resources and _get_columns_and_keys to avoid duplication.
+    RESOURCE_COLUMNS: Dict[str, Dict[str, Tuple[List[str], List[str]]]] = {
+        "Pods": {
+            "all": (["Name", "Namespace", "Status", "Ready", "Restarts"],
+                    ["name", "namespace", "status", "ready", "restarts"]),
+            "single": (["Name", "Status", "Ready", "Restarts"],
+                       ["name", "status", "ready", "restarts"]),
+        },
+        "Deployments": {
+            "all": (["Name", "Namespace", "Replicas", "Ready", "Available"],
+                    ["name", "namespace", "replicas", "ready_replicas", "available_replicas"]),
+            "single": (["Name", "Replicas", "Ready", "Available"],
+                       ["name", "replicas", "ready_replicas", "available_replicas"]),
+        },
+        "ReplicaSets": {
+            "all": (["Name", "Namespace", "Desired", "Ready", "Available"],
+                    ["name", "namespace", "desired", "ready", "available"]),
+            "single": (["Name", "Desired", "Ready", "Available"],
+                       ["name", "desired", "ready", "available"]),
+        },
+        "StatefulSets": {
+            "all": (["Name", "Namespace", "Ready", "Age"],
+                    ["name", "namespace", "ready", "age"]),
+            "single": (["Name", "Ready", "Age"],
+                       ["name", "ready", "age"]),
+        },
+        "DaemonSets": {
+            "all": (["Name", "Namespace", "Desired", "Ready", "Node Selector"],
+                    ["name", "namespace", "desired", "ready", "node_selector"]),
+            "single": (["Name", "Desired", "Ready", "Node Selector"],
+                       ["name", "desired", "ready", "node_selector"]),
+        },
+        "Jobs": {
+            "all": (["Name", "Namespace", "Completions", "Duration", "Status"],
+                    ["name", "namespace", "completions", "duration", "status"]),
+            "single": (["Name", "Completions", "Duration", "Status"],
+                       ["name", "completions", "duration", "status"]),
+        },
+        "CronJobs": {
+            "all": (["Name", "Namespace", "Schedule", "Last Run", "Active"],
+                    ["name", "namespace", "schedule", "last_run", "active"]),
+            "single": (["Name", "Schedule", "Last Run", "Active"],
+                       ["name", "schedule", "last_run", "active"]),
+        },
+        "Services": {
+            "all": (["Name", "Namespace", "Type", "Cluster IP"],
+                    ["name", "namespace", "type", "cluster_ip"]),
+            "single": (["Name", "Type", "Cluster IP"],
+                       ["name", "type", "cluster_ip"]),
+        },
+        "Ingresses": {
+            "all": (["Name", "Namespace", "Class", "Hosts", "Address"],
+                    ["name", "namespace", "class", "hosts", "address"]),
+            "single": (["Name", "Class", "Hosts", "Address"],
+                       ["name", "class", "hosts", "address"]),
+        },
+        "Endpoints": {
+            "all": (["Name", "Namespace", "Endpoints"],
+                    ["name", "namespace", "endpoints"]),
+            "single": (["Name", "Endpoints"],
+                       ["name", "endpoints"]),
+        },
+        "ConfigMaps": {
+            "all": (["Name", "Namespace", "Keys"],
+                    ["name", "namespace", "key_count"]),
+            "single": (["Name", "Keys"],
+                       ["name", "key_count"]),
+        },
+        "Secrets": {
+            "all": (["Name", "Namespace", "Type", "Keys"],
+                    ["name", "namespace", "type", "keys"]),
+            "single": (["Name", "Type", "Keys"],
+                       ["name", "type", "keys"]),
+        },
+        "PersistentVolumeClaims": {
+            "all": (["Name", "Namespace", "Status", "Volume", "Capacity"],
+                    ["name", "namespace", "status", "volume", "capacity"]),
+            "single": (["Name", "Status", "Volume", "Capacity"],
+                       ["name", "status", "volume", "capacity"]),
+        },
+        "PersistentVolumes": {
+            "all": (["Name", "Capacity", "Access Modes", "Status"],
+                    ["name", "capacity", "access_modes", "status"]),
+            "single": (["Name", "Capacity", "Access Modes", "Status"],
+                       ["name", "capacity", "access_modes", "status"]),
+        },
+        "Namespaces": {
+            "all": (["Name", "Status", "Age"], ["name", "status", "age"]),
+            "single": (["Name", "Status", "Age"], ["name", "status", "age"]),
+        },
+        "Nodes": {
+            "all": (["Name", "Status", "Roles", "Version"],
+                    ["name", "status", "roles", "version"]),
+            "single": (["Name", "Status", "Roles", "Version"],
+                       ["name", "status", "roles", "version"]),
+        },
+    }
+
     current_resource_type = reactive("Pods", init=False)
     current_namespace = reactive("default")
     current_context = reactive("N/A")
@@ -549,107 +648,8 @@ class ClusterScreen(Screen):
         # Check if we're in all-namespace mode
         is_all_namespaces = namespace == "all"
 
-        if resource_type == "Pods":
-            if is_all_namespaces:
-                columns = ["Name", "Namespace", "Status", "Ready", "Restarts"]
-                keys = ["name", "namespace", "status", "ready", "restarts"]
-            else:
-                columns = ["Name", "Status", "Ready", "Restarts"]
-                keys = ["name", "status", "ready", "restarts"]
-        elif resource_type == "Deployments":
-            if is_all_namespaces:
-                columns = ["Name", "Namespace", "Replicas", "Ready", "Available"]
-                keys = ["name", "namespace", "replicas", "ready_replicas", "available_replicas"]
-            else:
-                columns = ["Name", "Replicas", "Ready", "Available"]
-                keys = ["name", "replicas", "ready_replicas", "available_replicas"]
-        elif resource_type == "ReplicaSets":
-            if is_all_namespaces:
-                columns = ["Name", "Namespace", "Desired", "Ready", "Available"]
-                keys = ["name", "namespace", "desired", "ready", "available"]
-            else:
-                columns = ["Name", "Desired", "Ready", "Available"]
-                keys = ["name", "desired", "ready", "available"]
-        elif resource_type == "StatefulSets":
-            if is_all_namespaces:
-                columns = ["Name", "Namespace", "Ready", "Age"]
-                keys = ["name", "namespace", "ready", "age"]
-            else:
-                columns = ["Name", "Ready", "Age"]
-                keys = ["name", "ready", "age"]
-        elif resource_type == "DaemonSets":
-            if is_all_namespaces:
-                columns = ["Name", "Namespace", "Desired", "Ready", "Node Selector"]
-                keys = ["name", "namespace", "desired", "ready", "node_selector"]
-            else:
-                columns = ["Name", "Desired", "Ready", "Node Selector"]
-                keys = ["name", "desired", "ready", "node_selector"]
-        elif resource_type == "Jobs":
-            if is_all_namespaces:
-                columns = ["Name", "Namespace", "Completions", "Duration", "Status"]
-                keys = ["name", "namespace", "completions", "duration", "status"]
-            else:
-                columns = ["Name", "Completions", "Duration", "Status"]
-                keys = ["name", "completions", "duration", "status"]
-        elif resource_type == "CronJobs":
-            if is_all_namespaces:
-                columns = ["Name", "Namespace", "Schedule", "Last Run", "Active"]
-                keys = ["name", "namespace", "schedule", "last_run", "active"]
-            else:
-                columns = ["Name", "Schedule", "Last Run", "Active"]
-                keys = ["name", "schedule", "last_run", "active"]
-        elif resource_type == "Services":
-            if is_all_namespaces:
-                columns = ["Name", "Namespace", "Type", "Cluster IP"]
-                keys = ["name", "namespace", "type", "cluster_ip"]
-            else:
-                columns = ["Name", "Type", "Cluster IP"]
-                keys = ["name", "type", "cluster_ip"]
-        elif resource_type == "Ingresses":
-            if is_all_namespaces:
-                columns = ["Name", "Namespace", "Class", "Hosts", "Address"]
-                keys = ["name", "namespace", "class", "hosts", "address"]
-            else:
-                columns = ["Name", "Class", "Hosts", "Address"]
-                keys = ["name", "class", "hosts", "address"]
-        elif resource_type == "Endpoints":
-            if is_all_namespaces:
-                columns = ["Name", "Namespace", "Endpoints"]
-                keys = ["name", "namespace", "endpoints"]
-            else:
-                columns = ["Name", "Endpoints"]
-                keys = ["name", "endpoints"]
-        elif resource_type == "ConfigMaps":
-            if is_all_namespaces:
-                columns = ["Name", "Namespace", "Keys"]
-                keys = ["name", "namespace", "key_count"]
-            else:
-                columns = ["Name", "Keys"]
-                keys = ["name", "key_count"]
-        elif resource_type == "Secrets":
-            if is_all_namespaces:
-                columns = ["Name", "Namespace", "Type", "Keys"]
-                keys = ["name", "namespace", "type", "keys"]
-            else:
-                columns = ["Name", "Type", "Keys"]
-                keys = ["name", "type", "keys"]
-        elif resource_type == "PersistentVolumeClaims":
-            if is_all_namespaces:
-                columns = ["Name", "Namespace", "Status", "Volume", "Capacity"]
-                keys = ["name", "namespace", "status", "volume", "capacity"]
-            else:
-                columns = ["Name", "Status", "Volume", "Capacity"]
-                keys = ["name", "status", "volume", "capacity"]
-        elif resource_type == "PersistentVolumes":
-            columns = ["Name", "Capacity", "Access Modes", "Status"]
-            keys = ["name", "capacity", "access_modes", "status"]
-        elif resource_type == "Namespaces":
-            columns = ["Name", "Status", "Age"]
-            keys = ["name", "status", "age"]
-        elif resource_type == "Nodes":
-            columns = ["Name", "Status", "Roles", "Version"]
-            keys = ["name", "status", "roles", "version"]
-        else:
+        columns, keys = self._get_columns_and_keys(resource_type, is_all_namespaces)
+        if not columns:
             return
 
         # Store raw resources for re-filtering when the expression changes.
@@ -679,11 +679,16 @@ class ClusterScreen(Screen):
         """Show and focus the advanced filter panel."""
         filter_panel: FilterPanel = self.query_one("#filter-panel", FilterPanel)
         filter_panel.add_class("show")
+        self.current_panel = "filter"
         try:
-            inp = filter_panel.query_one("#filter-expr-input")
+            inp = filter_panel.query_one("#filter-expr-input", Input)
             inp.focus()
-        except Exception:
+        except NoMatches:
             filter_panel.focus()
+
+    def on_filter_panel_filter_dismissed(self, event: FilterPanel.FilterDismissed) -> None:
+        """Reset panel focus when filter panel is dismissed."""
+        self.current_panel = "table"
 
     def on_filter_panel_filter_changed(self, event: FilterPanel.FilterChanged) -> None:
         """Apply the filter expression to the current resource data."""
@@ -703,96 +708,21 @@ class ClusterScreen(Screen):
         except Exception:
             pass
 
-    def _get_columns_and_keys(self):
-        """Return (columns, keys) for the current resource type and namespace."""
-        resource_type = self.current_resource_type
-        is_all = self.current_namespace == "all"
-
-        mapping = {
-            "Pods": (
-                ["Name", "Namespace", "Status", "Ready", "Restarts"] if is_all
-                else ["Name", "Status", "Ready", "Restarts"],
-                ["name", "namespace", "status", "ready", "restarts"] if is_all
-                else ["name", "status", "ready", "restarts"],
-            ),
-            "Deployments": (
-                ["Name", "Namespace", "Replicas", "Ready", "Available"] if is_all
-                else ["Name", "Replicas", "Ready", "Available"],
-                ["name", "namespace", "replicas", "ready_replicas", "available_replicas"] if is_all
-                else ["name", "replicas", "ready_replicas", "available_replicas"],
-            ),
-            "ReplicaSets": (
-                ["Name", "Namespace", "Desired", "Ready", "Available"] if is_all
-                else ["Name", "Desired", "Ready", "Available"],
-                ["name", "namespace", "desired", "ready", "available"] if is_all
-                else ["name", "desired", "ready", "available"],
-            ),
-            "StatefulSets": (
-                ["Name", "Namespace", "Ready", "Age"] if is_all else ["Name", "Ready", "Age"],
-                ["name", "namespace", "ready", "age"] if is_all else ["name", "ready", "age"],
-            ),
-            "DaemonSets": (
-                ["Name", "Namespace", "Desired", "Ready", "Node Selector"] if is_all
-                else ["Name", "Desired", "Ready", "Node Selector"],
-                ["name", "namespace", "desired", "ready", "node_selector"] if is_all
-                else ["name", "desired", "ready", "node_selector"],
-            ),
-            "Jobs": (
-                ["Name", "Namespace", "Completions", "Duration", "Status"] if is_all
-                else ["Name", "Completions", "Duration", "Status"],
-                ["name", "namespace", "completions", "duration", "status"] if is_all
-                else ["name", "completions", "duration", "status"],
-            ),
-            "CronJobs": (
-                ["Name", "Namespace", "Schedule", "Last Run", "Active"] if is_all
-                else ["Name", "Schedule", "Last Run", "Active"],
-                ["name", "namespace", "schedule", "last_run", "active"] if is_all
-                else ["name", "schedule", "last_run", "active"],
-            ),
-            "Services": (
-                ["Name", "Namespace", "Type", "Cluster IP"] if is_all
-                else ["Name", "Type", "Cluster IP"],
-                ["name", "namespace", "type", "cluster_ip"] if is_all
-                else ["name", "type", "cluster_ip"],
-            ),
-            "Ingresses": (
-                ["Name", "Namespace", "Class", "Hosts", "Address"] if is_all
-                else ["Name", "Class", "Hosts", "Address"],
-                ["name", "namespace", "class", "hosts", "address"] if is_all
-                else ["name", "class", "hosts", "address"],
-            ),
-            "Endpoints": (
-                ["Name", "Namespace", "Endpoints"] if is_all else ["Name", "Endpoints"],
-                ["name", "namespace", "endpoints"] if is_all else ["name", "endpoints"],
-            ),
-            "ConfigMaps": (
-                ["Name", "Namespace", "Keys"] if is_all else ["Name", "Keys"],
-                ["name", "namespace", "key_count"] if is_all else ["name", "key_count"],
-            ),
-            "Secrets": (
-                ["Name", "Namespace", "Type", "Keys"] if is_all else ["Name", "Type", "Keys"],
-                ["name", "namespace", "type", "keys"] if is_all else ["name", "type", "keys"],
-            ),
-            "PersistentVolumeClaims": (
-                ["Name", "Namespace", "Status", "Volume", "Capacity"] if is_all
-                else ["Name", "Status", "Volume", "Capacity"],
-                ["name", "namespace", "status", "volume", "capacity"] if is_all
-                else ["name", "status", "volume", "capacity"],
-            ),
-            "PersistentVolumes": (
-                ["Name", "Capacity", "Access Modes", "Status"],
-                ["name", "capacity", "access_modes", "status"],
-            ),
-            "Namespaces": (
-                ["Name", "Status", "Age"],
-                ["name", "status", "age"],
-            ),
-            "Nodes": (
-                ["Name", "Status", "Roles", "Version"],
-                ["name", "status", "roles", "version"],
-            ),
-        }
-        return mapping.get(resource_type, ([], []))
+    def _get_columns_and_keys(
+        self,
+        resource_type: Optional[str] = None,
+        is_all: Optional[bool] = None,
+    ) -> Tuple[List[str], List[str]]:
+        """Return (columns, keys) for the given or current resource type and namespace mode."""
+        if resource_type is None:
+            resource_type = self.current_resource_type
+        if is_all is None:
+            is_all = self.current_namespace == "all"
+        entry = self.RESOURCE_COLUMNS.get(resource_type)
+        if entry is None:
+            return ([], [])
+        variant = "all" if is_all else "single"
+        return entry[variant]
 
     def action_describe_resource(self) -> None:
         """Describe the selected resource."""

--- a/src/gantry/screens.py
+++ b/src/gantry/screens.py
@@ -2,7 +2,7 @@
 
 import logging
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, ClassVar, Dict, List, Optional, Tuple
 from textual.screen import Screen, ModalScreen
 from textual.containers import Container, Vertical, Horizontal, ScrollableContainer, VerticalScroll
 from textual.widgets import Label, Static, Button, OptionList, Input, TextArea, ListView, ListItem, DirectoryTree
@@ -323,7 +323,7 @@ class ClusterScreen(Screen):
 
     # Maps resource_type -> {"all": (columns, keys), "single": (columns, keys)}
     # Used by both _display_resources and _get_columns_and_keys to avoid duplication.
-    RESOURCE_COLUMNS: Dict[str, Dict[str, Tuple[List[str], List[str]]]] = {
+    RESOURCE_COLUMNS: ClassVar[Dict[str, Dict[str, Tuple[List[str], List[str]]]]] = {
         "Pods": {
             "all": (["Name", "Namespace", "Status", "Ready", "Restarts"],
                     ["name", "namespace", "status", "ready", "restarts"]),
@@ -698,15 +698,14 @@ class ClusterScreen(Screen):
     def _apply_active_filter(self) -> None:
         """Filter _raw_resources by _active_filter and repopulate the table."""
         filtered = k8s.filter_resources(self._raw_resources, self._active_filter)
-        # Keep _resource_data in sync with what the table shows.
         self._resource_data = filtered
         try:
             table: ResourceTable = self.query_one("#resource-table", ResourceTable)
-            columns, keys = self._get_columns_and_keys()
-            if columns:
-                table.populate_resources(filtered, columns, keys)
-        except Exception:
-            pass
+        except NoMatches:
+            return
+        columns, keys = self._get_columns_and_keys()
+        if columns:
+            table.populate_resources(filtered, columns, keys)
 
     def _get_columns_and_keys(
         self,
@@ -1139,6 +1138,13 @@ class ClusterScreen(Screen):
 
     def watch_current_resource_type(self, new_type: str) -> None:
         """React to resource type changes."""
+        if self._active_filter:
+            self._active_filter = ""
+            try:
+                fp = self.query_one("#filter-panel", FilterPanel)
+                fp.query_one("#filter-expr-input", Input).value = ""
+            except NoMatches:
+                pass
         self._refresh_resources()
 
     def watch_current_panel(self, new_panel: str) -> None:

--- a/src/gantry/widgets.py
+++ b/src/gantry/widgets.py
@@ -1,14 +1,19 @@
 """Custom widgets for Gantry TUI."""
 
+import json
 import logging
+import re
+import time
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Callable, Tuple
 from rich.text import Text
-from textual.widgets import DataTable, Static, Input
+from textual.widgets import DataTable, Static, Input, Button, Label
 from textual.containers import Container, Horizontal, Vertical
 from textual.message import Message
 from textual.events import Key, MouseDown
 from textual.css.query import NoMatches
+from textual.widget import Widget
 
 logger = logging.getLogger(__name__)
 
@@ -461,9 +466,225 @@ class KeybindingsBar(Static):
 
         # Case 4 & 5: Normal state (depends on screen type)
         if self.screen_type == "cluster":
-            return "←→ Navigate | d Describe | l Logs | r Refresh | c Context | / Search | Tab Helm | q Quit"
+            return "←→ Navigate | d Describe | l Logs | r Refresh | c Context | / Search | f Filter | Tab Helm | q Quit"
         elif self.screen_type == "helm":
             return "↑↓ Navigate | ↵ Expand | r Refresh | Tab Cluster | q Quit"
 
         # Fallback (should not reach here)
         return ""
+
+
+_PRESETS_FILE = Path.home() / ".config" / "gantry" / "filter_presets.json"
+
+
+def _load_filter_presets() -> Dict[str, str]:
+    """Load saved filter presets from disk."""
+    try:
+        if _PRESETS_FILE.exists():
+            data = json.loads(_PRESETS_FILE.read_text())
+            if isinstance(data, dict):
+                return data
+    except Exception:
+        pass
+    return {}
+
+
+def _save_filter_presets(presets: Dict[str, str]) -> None:
+    """Persist filter presets to disk."""
+    try:
+        _PRESETS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        _PRESETS_FILE.write_text(json.dumps(presets, indent=2))
+    except Exception:
+        pass
+
+
+class FilterPanel(Widget):
+    """
+    Advanced filter panel for Kubernetes resources.
+
+    Supports a rich filter expression syntax:
+      name:nginx          - substring match on name
+      name:/regex/        - regex match on name
+      status:Running      - exact status (case-insensitive)
+      label:app=web       - label key=value
+      label:app           - label key present
+      annotation:k=v      - annotation match
+      namespace:default   - namespace substring
+      age:<1h             - younger than 1 hour (s/m/h/d)
+      age:>2d             - older than 2 days
+      /pattern/           - regex across all string fields
+
+    Terms can be combined with AND / OR.
+    Presets can be saved and loaded from ~/.config/gantry/filter_presets.json.
+    """
+
+    PLACEHOLDER = "filter: name:nginx OR label:app=web AND status:Running"
+
+    class FilterChanged(Message):
+        """Posted when the filter expression changes."""
+        def __init__(self, filter_expr: str) -> None:
+            self.filter_expr = filter_expr
+            super().__init__()
+
+    class PresetLoaded(Message):
+        """Posted when a preset is loaded."""
+        def __init__(self, name: str, filter_expr: str) -> None:
+            self.name = name
+            self.filter_expr = filter_expr
+            super().__init__()
+
+    CSS = """
+    FilterPanel {
+        height: auto;
+        width: 100%;
+        display: none;
+        border: solid $accent;
+        background: $panel;
+        padding: 0 1;
+    }
+
+    FilterPanel.show {
+        display: block;
+    }
+
+    #filter-row {
+        height: 3;
+        width: 100%;
+        align: left middle;
+    }
+
+    #filter-expr-input {
+        width: 1fr;
+        height: 1;
+        margin: 0 1 0 0;
+    }
+
+    #filter-badge {
+        width: auto;
+        min-width: 10;
+        height: 1;
+        margin: 0 1 0 0;
+        color: $accent;
+    }
+
+    #filter-clear-btn {
+        width: auto;
+        height: 1;
+        margin: 0 1 0 0;
+        min-width: 7;
+    }
+
+    #filter-save-btn {
+        width: auto;
+        height: 1;
+        min-width: 13;
+    }
+
+    #preset-hint {
+        height: 1;
+        color: $text-muted;
+        padding: 0 0 0 1;
+    }
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._filter_expr: str = ""
+        self._presets: Dict[str, str] = _load_filter_presets()
+
+    def compose(self):
+        """Compose the filter panel UI."""
+        with Horizontal(id="filter-row"):
+            yield Input(
+                placeholder=self.PLACEHOLDER,
+                id="filter-expr-input",
+            )
+            yield Label("0 filters", id="filter-badge")
+            yield Button("Clear", id="filter-clear-btn", variant="default")
+            yield Button("Save preset", id="filter-save-btn", variant="primary")
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        """Propagate filter changes and update badge."""
+        if event.input.id == "filter-expr-input":
+            self._filter_expr = event.value
+            self._update_badge()
+            self.post_message(self.FilterChanged(event.value))
+
+    def _on_key(self, event: Key) -> None:
+        """Handle escape/enter to hide panel."""
+        if event.key == "escape":
+            event.stop()
+            self.remove_class("show")
+            try:
+                table = self.screen.query_one(ResourceTable)
+                table.focus()
+            except NoMatches:
+                pass
+        elif event.key == "enter":
+            event.stop()
+            self.remove_class("show")
+            try:
+                table = self.screen.query_one(ResourceTable)
+                table.focus()
+            except NoMatches:
+                pass
+        # Other keys are not stopped here so they bubble normally.
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Handle Clear and Save preset buttons."""
+        if event.button.id == "filter-clear-btn":
+            self._clear()
+        elif event.button.id == "filter-save-btn":
+            self._save_current_as_preset()
+
+    def _clear(self) -> None:
+        """Clear the current filter expression."""
+        try:
+            inp = self.query_one("#filter-expr-input", Input)
+            inp.value = ""
+        except NoMatches:
+            pass
+
+    def _save_current_as_preset(self) -> None:
+        """Save current expression as a numbered preset."""
+        if not self._filter_expr.strip():
+            return
+        name = f"preset_{int(time.time())}"
+        self._presets[name] = self._filter_expr.strip()
+        _save_filter_presets(self._presets)
+        logger.debug(f"FilterPanel: saved preset {name!r} = {self._filter_expr!r}")
+
+    def load_preset(self, name: str) -> None:
+        """Load a named preset into the filter input."""
+        expr = self._presets.get(name, "")
+        try:
+            inp = self.query_one("#filter-expr-input", Input)
+            inp.value = expr
+        except NoMatches:
+            pass
+        self.post_message(self.PresetLoaded(name, expr))
+
+    def get_presets(self) -> Dict[str, str]:
+        """Return the current presets dict (name -> expression)."""
+        self._presets = _load_filter_presets()
+        return self._presets
+
+    def _update_badge(self) -> None:
+        """Update the active-filter-count badge."""
+        expr = self._filter_expr.strip()
+        if not expr:
+            count = 0
+        else:
+            terms = re.split(r"\s+(?:AND|OR)\s+", expr, flags=re.IGNORECASE)
+            count = len([t for t in terms if t.strip()])
+        try:
+            badge = self.query_one("#filter-badge", Label)
+            label_text = f"{count} filter{'s' if count != 1 else ''}"
+            badge.update(label_text)
+        except NoMatches:
+            pass
+
+    @property
+    def filter_expr(self) -> str:
+        """Return the current filter expression."""
+        return self._filter_expr

--- a/src/gantry/widgets.py
+++ b/src/gantry/widgets.py
@@ -461,6 +461,10 @@ class KeybindingsBar(Static):
         if self.search_active:
             return "Esc Cancel | ↵ Select"
 
+        # Case 2b: Filter panel active
+        if self.current_panel == "filter":
+            return "Esc/↵ Close | AND/OR | name:… label:… status:… age:<1h"
+
         # Case 3: Helm screen with file preview showing
         if self.screen_type == "helm" and self.helm_preview_open:
             return "↑↓ Navigate | ↵ Expand | Esc Clear preview | r Refresh | Tab Cluster | q Quit"
@@ -598,6 +602,12 @@ class FilterPanel(Widget):
         height: 1;
     }
 
+    #preset-name-input {
+        width: 1fr;
+        height: 1;
+        margin: 0 1;
+    }
+
     #preset-hint {
         height: 1;
         color: $text-muted;
@@ -609,6 +619,7 @@ class FilterPanel(Widget):
         super().__init__(*args, **kwargs)
         self._filter_expr: str = ""
         self._presets: Dict[str, str] = _load_filter_presets()
+        self._filter_timer = None
 
     def compose(self):
         """Compose the filter panel UI."""
@@ -619,7 +630,6 @@ class FilterPanel(Widget):
             )
             yield Label("0 filters", id="filter-badge")
             yield Button("Clear", id="filter-clear-btn", variant="default")
-            yield Button("Save preset", id="filter-save-btn", variant="primary")
         preset_options = [(name, name) for name in self._presets]
         with Horizontal(id="preset-row"):
             yield Select(
@@ -628,13 +638,22 @@ class FilterPanel(Widget):
                 id="filter-preset-select",
                 allow_blank=True,
             )
+            yield Input(placeholder="preset name…", id="preset-name-input")
+            yield Button("Save", id="filter-save-btn", variant="primary")
 
     def on_input_changed(self, event: Input.Changed) -> None:
-        """Propagate filter changes and update badge."""
+        """Propagate filter changes and update badge (debounced)."""
         if event.input.id == "filter-expr-input":
             self._filter_expr = event.value
             self._update_badge()
-            self.post_message(self.FilterChanged(event.value))
+            if self._filter_timer is not None:
+                self._filter_timer.stop()
+            self._filter_timer = self.set_timer(0.25, self._post_filter_changed)
+
+    def _post_filter_changed(self) -> None:
+        """Post FilterChanged after debounce delay."""
+        self._filter_timer = None
+        self.post_message(self.FilterChanged(self._filter_expr))
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
         """Hide panel when user presses Enter inside the filter expression input."""
@@ -678,19 +697,32 @@ class FilterPanel(Widget):
             pass
 
     def _save_current_as_preset(self) -> None:
-        """Save current expression as a uniquely-named preset."""
+        """Save current expression as a named preset (uses input field, falls back to auto-name)."""
         if not self._filter_expr.strip():
             return
-        base = "preset"
-        name = base
-        counter = 1
-        while name in self._presets:
-            name = f"{base}_{counter}"
-            counter += 1
+        user_name = ""
+        try:
+            name_inp = self.query_one("#preset-name-input", Input)
+            user_name = name_inp.value.strip()
+        except NoMatches:
+            pass
+        if user_name:
+            name = user_name
+        else:
+            base = "preset"
+            name = base
+            counter = 1
+            while name in self._presets:
+                name = f"{base}_{counter}"
+                counter += 1
         self._presets[name] = self._filter_expr.strip()
         _save_filter_presets(self._presets)
         self._refresh_preset_select()
         logger.debug("FilterPanel: saved preset %r = %r", name, self._filter_expr)
+        try:
+            self.query_one("#preset-name-input", Input).value = ""
+        except NoMatches:
+            pass
 
     def _refresh_preset_select(self) -> None:
         """Update the preset Select widget options after saves."""

--- a/src/gantry/widgets.py
+++ b/src/gantry/widgets.py
@@ -2,13 +2,14 @@
 
 import json
 import logging
+import os
 import re
 import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Callable, Tuple
 from rich.text import Text
-from textual.widgets import DataTable, Static, Input, Button, Label
+from textual.widgets import DataTable, Static, Input, Button, Label, Select
 from textual.containers import Container, Horizontal, Vertical
 from textual.message import Message
 from textual.events import Key, MouseDown
@@ -474,7 +475,8 @@ class KeybindingsBar(Static):
         return ""
 
 
-_PRESETS_FILE = Path.home() / ".config" / "gantry" / "filter_presets.json"
+_CONFIG_HOME = Path(os.environ.get("XDG_CONFIG_HOME") or (Path.home() / ".config"))
+_PRESETS_FILE = _CONFIG_HOME / "gantry" / "filter_presets.json"
 
 
 def _load_filter_presets() -> Dict[str, str]:
@@ -484,18 +486,20 @@ def _load_filter_presets() -> Dict[str, str]:
             data = json.loads(_PRESETS_FILE.read_text())
             if isinstance(data, dict):
                 return data
-    except Exception:
-        pass
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("Failed to load filter presets from %s: %s", _PRESETS_FILE, exc)
     return {}
 
 
-def _save_filter_presets(presets: Dict[str, str]) -> None:
-    """Persist filter presets to disk."""
+def _save_filter_presets(presets: Dict[str, str]) -> bool:
+    """Persist filter presets to disk. Returns True on success."""
     try:
         _PRESETS_FILE.parent.mkdir(parents=True, exist_ok=True)
         _PRESETS_FILE.write_text(json.dumps(presets, indent=2))
-    except Exception:
-        pass
+        return True
+    except OSError as exc:
+        logger.error("Failed to save filter presets to %s: %s", _PRESETS_FILE, exc)
+        return False
 
 
 class FilterPanel(Widget):
@@ -525,6 +529,9 @@ class FilterPanel(Widget):
         def __init__(self, filter_expr: str) -> None:
             self.filter_expr = filter_expr
             super().__init__()
+
+    class FilterDismissed(Message):
+        """Posted when the filter panel is hidden (Escape or Enter)."""
 
     class PresetLoaded(Message):
         """Posted when a preset is loaded."""
@@ -580,6 +587,17 @@ class FilterPanel(Widget):
         min-width: 13;
     }
 
+    #preset-row {
+        height: 3;
+        width: 100%;
+        align: left middle;
+    }
+
+    #filter-preset-select {
+        width: 1fr;
+        height: 1;
+    }
+
     #preset-hint {
         height: 1;
         color: $text-muted;
@@ -602,6 +620,14 @@ class FilterPanel(Widget):
             yield Label("0 filters", id="filter-badge")
             yield Button("Clear", id="filter-clear-btn", variant="default")
             yield Button("Save preset", id="filter-save-btn", variant="primary")
+        preset_options = [(name, name) for name in self._presets]
+        with Horizontal(id="preset-row"):
+            yield Select(
+                options=preset_options,
+                prompt="Load preset…",
+                id="filter-preset-select",
+                allow_blank=True,
+            )
 
     def on_input_changed(self, event: Input.Changed) -> None:
         """Propagate filter changes and update badge."""
@@ -610,25 +636,31 @@ class FilterPanel(Widget):
             self._update_badge()
             self.post_message(self.FilterChanged(event.value))
 
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        """Hide panel when user presses Enter inside the filter expression input."""
+        if event.input.id == "filter-expr-input":
+            self._dismiss()
+
+    def on_select_changed(self, event: Select.Changed) -> None:
+        """Load a preset when selected from the dropdown."""
+        if event.select.id == "filter-preset-select" and event.value is not Select.BLANK:
+            self.load_preset(str(event.value))
+
     def _on_key(self, event: Key) -> None:
-        """Handle escape/enter to hide panel."""
+        """Handle escape to hide panel (Enter is handled via on_input_submitted)."""
         if event.key == "escape":
             event.stop()
-            self.remove_class("show")
-            try:
-                table = self.screen.query_one(ResourceTable)
-                table.focus()
-            except NoMatches:
-                pass
-        elif event.key == "enter":
-            event.stop()
-            self.remove_class("show")
-            try:
-                table = self.screen.query_one(ResourceTable)
-                table.focus()
-            except NoMatches:
-                pass
+            self._dismiss()
         # Other keys are not stopped here so they bubble normally.
+
+    def _dismiss(self) -> None:
+        """Hide the panel and notify the screen of dismissal."""
+        self.remove_class("show")
+        self.post_message(self.FilterDismissed())
+        try:
+            self.screen.query_one(ResourceTable).focus()
+        except NoMatches:
+            pass
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         """Handle Clear and Save preset buttons."""
@@ -646,13 +678,27 @@ class FilterPanel(Widget):
             pass
 
     def _save_current_as_preset(self) -> None:
-        """Save current expression as a numbered preset."""
+        """Save current expression as a uniquely-named preset."""
         if not self._filter_expr.strip():
             return
-        name = f"preset_{int(time.time())}"
+        base = "preset"
+        name = base
+        counter = 1
+        while name in self._presets:
+            name = f"{base}_{counter}"
+            counter += 1
         self._presets[name] = self._filter_expr.strip()
         _save_filter_presets(self._presets)
-        logger.debug(f"FilterPanel: saved preset {name!r} = {self._filter_expr!r}")
+        self._refresh_preset_select()
+        logger.debug("FilterPanel: saved preset %r = %r", name, self._filter_expr)
+
+    def _refresh_preset_select(self) -> None:
+        """Update the preset Select widget options after saves."""
+        try:
+            sel = self.query_one("#filter-preset-select", Select)
+            sel.set_options([(name, name) for name in self._presets])
+        except NoMatches:
+            pass
 
     def load_preset(self, name: str) -> None:
         """Load a named preset into the filter input."""

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -1137,3 +1137,178 @@ class TestGetResourceYaml:
     def test_get_resource_yaml_unsupported_type_returns_none_tuple(self, mock_config):
         result = k8s.get_resource_yaml("foobar", "test", "default")
         assert result == (None, None)
+
+
+# ---------------------------------------------------------------------------
+# Tests for filter_resources
+# ---------------------------------------------------------------------------
+
+SAMPLE_PODS = [
+    {
+        "name": "nginx-abc",
+        "namespace": "default",
+        "status": "Running",
+        "ready": 1,
+        "restarts": 0,
+        "age_seconds": None,
+        "_labels": {"app": "web", "env": "prod"},
+        "_annotations": {"owner": "alice"},
+    },
+    {
+        "name": "redis-xyz",
+        "namespace": "default",
+        "status": "Running",
+        "ready": 1,
+        "restarts": 2,
+        "age_seconds": None,
+        "_labels": {"app": "cache"},
+        "_annotations": {},
+    },
+    {
+        "name": "debug-pod",
+        "namespace": "kube-system",
+        "status": "Pending",
+        "ready": 0,
+        "restarts": 0,
+        "age_seconds": None,
+        "_labels": {"env": "dev"},
+        "_annotations": {"owner": "bob"},
+    },
+]
+
+
+class TestFilterResources:
+    """Tests for filter_resources function."""
+
+    def test_empty_expr_returns_all(self):
+        """Empty filter expression returns all resources unchanged."""
+        result = k8s.filter_resources(SAMPLE_PODS, "")
+        assert result == SAMPLE_PODS
+
+    def test_whitespace_expr_returns_all(self):
+        """Whitespace-only expression returns all resources."""
+        result = k8s.filter_resources(SAMPLE_PODS, "   ")
+        assert result == SAMPLE_PODS
+
+    def test_name_substring(self):
+        """name:pattern filters by substring on the name field."""
+        result = k8s.filter_resources(SAMPLE_PODS, "name:nginx")
+        assert len(result) == 1
+        assert result[0]["name"] == "nginx-abc"
+
+    def test_name_regex(self):
+        """name:/regex/ performs a regex match on the name field."""
+        result = k8s.filter_resources(SAMPLE_PODS, "name:/nginx|redis/")
+        assert len(result) == 2
+        names = {r["name"] for r in result}
+        assert names == {"nginx-abc", "redis-xyz"}
+
+    def test_status_match(self):
+        """status:value filters by exact status (case-insensitive)."""
+        result = k8s.filter_resources(SAMPLE_PODS, "status:Pending")
+        assert len(result) == 1
+        assert result[0]["name"] == "debug-pod"
+
+    def test_status_case_insensitive(self):
+        """status filter is case-insensitive."""
+        result = k8s.filter_resources(SAMPLE_PODS, "status:running")
+        assert len(result) == 2
+
+    def test_label_key_value(self):
+        """label:key=value matches exact label value."""
+        result = k8s.filter_resources(SAMPLE_PODS, "label:app=web")
+        assert len(result) == 1
+        assert result[0]["name"] == "nginx-abc"
+
+    def test_label_key_only(self):
+        """label:key matches any resource that has the label key."""
+        result = k8s.filter_resources(SAMPLE_PODS, "label:env")
+        assert len(result) == 2
+        names = {r["name"] for r in result}
+        assert names == {"nginx-abc", "debug-pod"}
+
+    def test_annotation_key_value(self):
+        """annotation:key=value matches exact annotation value."""
+        result = k8s.filter_resources(SAMPLE_PODS, "annotation:owner=alice")
+        assert len(result) == 1
+        assert result[0]["name"] == "nginx-abc"
+
+    def test_annotation_key_only(self):
+        """annotation:key matches any resource that has the annotation key."""
+        result = k8s.filter_resources(SAMPLE_PODS, "annotation:owner")
+        assert len(result) == 2
+
+    def test_namespace_substring(self):
+        """namespace:value filters by substring on the namespace field."""
+        result = k8s.filter_resources(SAMPLE_PODS, "namespace:kube-system")
+        assert len(result) == 1
+        assert result[0]["name"] == "debug-pod"
+
+    def test_and_logic(self):
+        """AND combines two predicates both must be true."""
+        result = k8s.filter_resources(SAMPLE_PODS, "status:Running AND label:app=web")
+        assert len(result) == 1
+        assert result[0]["name"] == "nginx-abc"
+
+    def test_or_logic(self):
+        """OR returns resources matching either predicate."""
+        result = k8s.filter_resources(SAMPLE_PODS, "label:app=web OR label:app=cache")
+        assert len(result) == 2
+        names = {r["name"] for r in result}
+        assert names == {"nginx-abc", "redis-xyz"}
+
+    def test_and_or_combined(self):
+        """AND binds tighter than OR (left-to-right)."""
+        # label:app=web AND status:Running → nginx-abc
+        # OR name:debug → debug-pod
+        result = k8s.filter_resources(
+            SAMPLE_PODS, "label:app=web AND status:Running OR name:debug"
+        )
+        assert len(result) == 2
+
+    def test_global_regex_search(self):
+        """/pattern/ searches across all non-private string fields."""
+        result = k8s.filter_resources(SAMPLE_PODS, "/nginx/")
+        assert len(result) == 1
+        assert result[0]["name"] == "nginx-abc"
+
+    def test_bare_substring_search(self):
+        """Bare term (no colon) does substring search across string fields."""
+        result = k8s.filter_resources(SAMPLE_PODS, "redis")
+        assert len(result) == 1
+        assert result[0]["name"] == "redis-xyz"
+
+    def test_no_match_returns_empty(self):
+        """Filter that matches nothing returns empty list."""
+        result = k8s.filter_resources(SAMPLE_PODS, "name:nonexistent")
+        assert result == []
+
+    def test_age_younger_than(self):
+        """age:<Xh matches resources with age_seconds > (now - X*3600)."""
+        import time
+        now = time.time()
+        resources = [
+            {"name": "young", "age_seconds": now - 300},   # 5 min old
+            {"name": "old", "age_seconds": now - 7200},    # 2 h old
+        ]
+        result = k8s.filter_resources(resources, "age:<1h")
+        assert len(result) == 1
+        assert result[0]["name"] == "young"
+
+    def test_age_older_than(self):
+        """age:>Xh matches resources with age_seconds < (now - X*3600)."""
+        import time
+        now = time.time()
+        resources = [
+            {"name": "young", "age_seconds": now - 300},
+            {"name": "old", "age_seconds": now - 7200},
+        ]
+        result = k8s.filter_resources(resources, "age:>1h")
+        assert len(result) == 1
+        assert result[0]["name"] == "old"
+
+    def test_invalid_regex_falls_back_gracefully(self):
+        """Invalid regex pattern falls back to no match rather than crashing."""
+        result = k8s.filter_resources(SAMPLE_PODS, "name:/[invalid/")
+        # Should not raise; just return empty or all depending on fallback
+        assert isinstance(result, list)

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -1221,6 +1221,8 @@ class TestFilterResources:
         """status filter is case-insensitive."""
         result = k8s.filter_resources(SAMPLE_PODS, "status:running")
         assert len(result) == 2
+        names = {r["name"] for r in result}
+        assert names == {"nginx-abc", "redis-xyz"}
 
     def test_label_key_value(self):
         """label:key=value matches exact label value."""
@@ -1245,6 +1247,8 @@ class TestFilterResources:
         """annotation:key matches any resource that has the annotation key."""
         result = k8s.filter_resources(SAMPLE_PODS, "annotation:owner")
         assert len(result) == 2
+        names = {r["name"] for r in result}
+        assert names == {"nginx-abc", "debug-pod"}
 
     def test_namespace_substring(self):
         """namespace:value filters by substring on the namespace field."""
@@ -1273,6 +1277,8 @@ class TestFilterResources:
             SAMPLE_PODS, "label:app=web AND status:Running OR name:debug"
         )
         assert len(result) == 2
+        names = {r["name"] for r in result}
+        assert names == {"nginx-abc", "debug-pod"}
 
     def test_global_regex_search(self):
         """/pattern/ searches across all non-private string fields."""

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -144,6 +144,8 @@ class TestListPods:
         pod1.metadata.creation_timestamp = MagicMock()
         pod1.metadata.creation_timestamp.timestamp.return_value = 1000.0
         pod1.spec.containers = [MagicMock(), MagicMock()]
+        pod1.metadata.labels = {"app": "nginx"}
+        pod1.metadata.annotations = None  # exercise the `or {}` fallback
 
         container_status1 = MagicMock()
         container_status1.ready = True
@@ -170,6 +172,8 @@ class TestListPods:
         assert result[0]["ready"] == 2
         assert result[0]["total_containers"] == 2
         assert result[0]["restarts"] == 2
+        assert result[0]["_labels"] == {"app": "nginx"}
+        assert result[0]["_annotations"] == {}
 
     @patch("gantry.k8s.config.load_kube_config")
     def test_list_pods_missing_kubeconfig(self, mock_load):
@@ -273,6 +277,8 @@ class TestListDeployments:
         deploy1.status.updated_replicas = 3
         deploy1.status.available_replicas = 3
         deploy1.spec.strategy.type = "RollingUpdate"
+        deploy1.metadata.labels = {"app": "nginx", "env": "prod"}
+        deploy1.metadata.annotations = None  # exercise the `or {}` fallback
 
         deploy_list = MagicMock()
         deploy_list.items = [deploy1]
@@ -288,6 +294,8 @@ class TestListDeployments:
         assert result[0]["replicas"] == 3
         assert result[0]["ready_replicas"] == 3
         assert result[0]["strategy_type"] == "RollingUpdate"
+        assert result[0]["_labels"] == {"app": "nginx", "env": "prod"}
+        assert result[0]["_annotations"] == {}
 
     @patch("gantry.k8s.config.load_kube_config")
     def test_list_deployments_missing_kubeconfig(self, mock_load):
@@ -1308,7 +1316,9 @@ class TestFilterResources:
         assert result[0]["name"] == "old"
 
     def test_invalid_regex_falls_back_gracefully(self):
-        """Invalid regex pattern falls back to no match rather than crashing."""
+        """Invalid regex pattern falls back to substring match on the literal value."""
         result = k8s.filter_resources(SAMPLE_PODS, "name:/[invalid/")
-        # Should not raise; just return empty or all depending on fallback
-        assert isinstance(result, list)
+        # Falls back to substring search of "/[invalid/" — no SAMPLE_PODS name contains it.
+        assert result == []
+        # And a bare invalid regex also falls back without raising.
+        assert k8s.filter_resources(SAMPLE_PODS, "/[invalid/") == []


### PR DESCRIPTION
Implements the Advanced Filters feature from issue #48.

## Changes
- `filter_resources()` in `k8s.py` with rich expression syntax (name, status, label, annotation, namespace, age, regex, AND/OR)
- `FilterPanel` widget in `widgets.py` with filter-count badge, clear & save-preset buttons
- Integrated into `ClusterScreen`: press `f` to open, real-time filtering
- Preset persistence at `~/.config/gantry/filter_presets.json`
- 24 new tests for `filter_resources()`

Closes #48

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Advanced resource filtering: substring search, regex, label/annotation matches, status and namespace matching, and age-based queries.
  * Filter panel UI with keyboard shortcut (f) and ability to save/load reusable presets.

* **Improvements**
  * Resource metadata (labels/annotations) are consistently exposed for filtering and display.

* **Tests**
  * Added comprehensive tests covering filtering behavior, edge cases, and age-based queries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iamtanbirahmed/gantry/pull/54)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->